### PR TITLE
UI overhaul to improve user experience

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,21 +136,23 @@ cd ..
 
 # 2. Run NudeNet CLI interactively
 python3 nudity-detector-nudenet.py
-# When prompted, enter: test_scenario
+# When prompted, enter:
+#  - folder: test_scenario
+#  - threshold: 60
 
 # 3. Verify outputs
-ls -la exposed/
-file exposed/nudity_report.xlsx
+ls -la reports/
+file reports/nudity_report.xlsx
 
 # 4. Clean up
-rm -rf test_scenario exposed
+rm -rf test_scenario reports
 ```
 
 Expected results:
 - Should process 2 images (test1.jpg, test2.png)
 - Should skip bad_file.txt with "unsupported file" message
-- Should create `exposed/` folder with `nudity_report.xlsx`
-- Should show "Report saved to exposed/nudity_report.xlsx"
+- Should create `reports/` folder with `nudity_report.xlsx`
+- Should show "Report saved to reports/nudity_report.xlsx"
 
 ### Manual Testing Scenarios
 - **Basic Image Processing**: Use the end-to-end scenario above
@@ -175,19 +177,19 @@ Expected results:
 ### Testing Changes
 - Always run validation scenarios above after making code changes
 - Test both NudeNet and DeepStack backends if modifying core detection logic
-- Verify report generation works by checking `exposed/nudity_report.xlsx` creation
+- Verify report generation works by checking `reports/nudity_report.xlsx` creation
 
 ## Common Tasks
 
 ### Repository Structure
 ```
 .
-├── README.md                          # Project documentation
-├── requirements.txt                   # Python dependencies  
-├── docker-compose.yml                 # DeepStack server config
+├── README.md                         # Project documentation
+├── requirements.txt                  # Python dependencies
+├── docker-compose.yml                # DeepStack server config
 ├── nudity_detector_gui.py            # GUI application (tkinter)
 ├── nudity-detector-nudenet.py        # NudeNet CLI
-├── nudity-detector-deepstack.py      # DeepStack CLI  
+├── nudity-detector-deepstack.py      # DeepStack CLI
 ├── nudity_detector_utils.py          # Shared utilities
 └── .github/
     └── copilot-instructions.md       # This file
@@ -201,8 +203,11 @@ Expected results:
 ```
 nudenet          # Local AI nudity detection
 vnudenet         # Enhanced nudity detection
-openpyxl         # Excel report generation  
+openpyxl         # Excel report generation
+Pillow           # Image thumbnail generation
+opencv-python    # Video frame extraction and thumbnail generation
 requests         # HTTP client for DeepStack API
+Send2Trash       # Safe file deletion to recycle bin/trash
 ```
 
 ### Environment Requirements
@@ -213,6 +218,6 @@ requests         # HTTP client for DeepStack API
 
 ### Troubleshooting
 - **GUI fails with "no display"**: Normal in headless environments, use CLI instead
-- **DeepStack API 404**: Wait 15+ seconds after container start for full initialization  
+- **DeepStack API 404**: Wait 15+ seconds after container start for full initialization
 - **Import errors**: Ensure `pip3 install -r requirements.txt` completed successfully
 - **Docker permission issues**: User must be in docker group or use sudo

--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,10 @@ dmypy.json
 .vscode/
 .history/
 
-# Exposed folder
+# Reports folder
 samples/
-exposed/
+reports/
+
+# AI
+.codegraph/
+openspec/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Nudity Detector
 
-This project, Nudity Detector, is a Python-based script designed to detect nudity in images and videos. It provides an
-An efficient and automated solution for identifying explicit content, making it suitable for applications such as content
+This project, Nudity Detector, is a Python-based application designed to detect nudity in images and videos. It provides an
+efficient and automated solution for identifying explicit content, making it suitable for applications such as content
 moderation, safety filters, and compliance checks.
 
 ## Overview
 
-The **Nudity Detector** script is a tool for identifying nudity in images and videos. It uses AI-based models to classify files and organizes detected content into a dedicated folder, generating a comprehensive report afterward.
+The **Nudity Detector** application identifies nudity in images and videos using AI-based models. It scans files, stores reports in a dedicated reports folder, and presents detected items in the GUI for review actions.
 
 Two versions of the script are available:
 
@@ -14,16 +14,19 @@ Two versions of the script are available:
   - Basic
   - Not always accurate
   - Process videos by extracting frames and analyzing the frames as images.
-- **DeepStack**: Uses the `DeepStack` AI server for detection. (In Progress)
+- **DeepStack**: Uses the `DeepStack` AI server for detection.
 
 ## Features
 
-1. **Graphical User Interface**: Easy-to-use tkinter GUI with model selection and progress tracking.
+1. **Graphical User Interface**: Easy-to-use tkinter GUI with theme selection, model selection, threshold control, and progress tracking.
 2. **File Classification**: Identifies nudity in supported image and video files.
-3. **File Management**: Copies files with detected nudity to an `exposed` folder for review.
-4. **Report Generation**: Creates an Excel report in the `exposed` folder summarizing detection results.
+3. **File Management**: Keeps detected files in their original location for direct review.
+4. **Report Generation**: Creates an Excel report in the `reports` folder summarizing detection results.
 5. **Multi-Threading**: Speeds up classification by processing files in parallel.
 6. **Real-time Progress**: Visual progress indicators and logging during scanning.
+7. **Saved Scan Sessions**: Stores scan settings and detected-media state so you can reload a prior review later.
+8. **Review Actions**: Lists detected images and videos with confidence scores and allows opening file locations or deleting files.
+9. **Thumbnail Support**: Generates and displays thumbnails in reports and in the GUI review pane.
 
 ---
 
@@ -59,12 +62,12 @@ Two versions of the script are available:
   ./.venv/bin/pip install -r requirements.txt
   ```
 
-4. **Install docker and docker compose**
+1. **Install docker and docker compose**
 
     - Follow the instructions for your OS on the official Docker website: <https://docs.docker.com/get-docker/>
     - Ensure Docker Compose is installed. Instructions can be found here: <https://docs.docker.com/compose/install/>
   
-5. **Perpare Models**:
+2. **Perpare Models**:
 
    - Nudenet
      - For Nudenet no setup is required.
@@ -82,7 +85,7 @@ Two versions of the script are available:
     curl -X POST -F image=@test.jpg 'http://localhost:5000/v1/vision/detection'
     ```
 
-6. **Run the process**:
+3. **Run the process**:
 
 ### Option 1: GUI Application (Recommended)
 
@@ -109,10 +112,14 @@ This will require tkinter to be installed.
   The GUI provides an easy-to-use interface with:
 
 - Model selection (NudeNet or DeepStack)
+- Theme selection (`system`, `light`, `dark`)
 - Folder browsing and selection
+- Detection threshold control in percentages
 - Progress tracking with visual indicators
-- Automatic report generation
-- Quick access to results and exposed files
+- Automatic report and session generation
+- Detected media review table with confidence percentages
+- Save/load workflow for returning to a previous review session
+- Quick access to reports and source file locations
 
 ### Option 2: Command Line
 
@@ -122,11 +129,19 @@ This will require tkinter to be installed.
   python3 nudity-detector-nudenet.py
   ```
 
+  Prompts:
+  - source folder path
+  - detection threshold percentage
+
 - Deepstack
 
     ```bash
   python3 nudity-detector-deepstack.py
   ```
+
+  Prompts:
+  - source folder path
+  - detection threshold percentage
 
 ## Supported File Formats
 
@@ -154,18 +169,46 @@ This will require tkinter to be installed.
 
 ## Output
 
-### Exposed Folder
+### Reports Folder
 
-Detected files are copied to an exposed folder created in the current directory.
+Reports are saved in a `reports` folder created in the current directory.
+
+Detected files are **not copied** into the reports folder; source files remain in their original location.
 
 ### Report File
 
-A detailed Excel report named nudity_report.xlsx is saved in the exposed folder.
+A detailed Excel report named nudity_report.xlsx is saved in the reports folder.
 The report includes:
 
 - File path
+- Media type
+- Model used
+- Threshold percentage
+- Confidence percentage
 - Nudity detection status
 - Detected nudity classes
+- Thumbnail image (embedded)
+
+### GUI Review
+
+The GUI review panel includes:
+
+- Detected-item table with confidence and source path
+- Thumbnail preview for selected result rows
+- `Open File` action to open the selected image/video directly
+- `Open Location` action to open the parent folder
+
+### Session State
+
+Each saved report now stores companion session data so the GUI can restore:
+
+- Theme mode
+- Source folder
+- Selected model
+- Detection threshold
+- Detected media rows with confidence and file paths
+
+Use the GUI `Save Session` and `Load Session` actions to resume review work later.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ Two versions of the script are available:
   ./.venv/bin/pip install -r requirements.txt
   ```
 
-1. **Install docker and docker compose**
+4. **Install docker and docker compose**
 
     - Follow the instructions for your OS on the official Docker website: <https://docs.docker.com/get-docker/>
     - Ensure Docker Compose is installed. Instructions can be found here: <https://docs.docker.com/compose/install/>
   
-2. **Perpare Models**:
+5. **Prepare Models**:
 
    - Nudenet
      - For Nudenet no setup is required.
@@ -85,7 +85,7 @@ Two versions of the script are available:
     curl -X POST -F image=@test.jpg 'http://localhost:5000/v1/vision/detection'
     ```
 
-3. **Run the process**:
+6. **Run the process**:
 
 ### Option 1: GUI Application (Recommended)
 

--- a/nudity-detector-deepstack.py
+++ b/nudity-detector-deepstack.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import tempfile
 
 import cv2
@@ -147,11 +148,7 @@ if __name__ == '__main__':
             logging.error('Error classifying video %s: %s', file_path, error)
         finally:
             if temp_dir and os.path.isdir(temp_dir):
-                for frame_name in os.listdir(temp_dir):
-                    frame_path = os.path.join(temp_dir, frame_name)
-                    if os.path.isfile(frame_path):
-                        os.remove(frame_path)
-                os.rmdir(temp_dir)
+                shutil.rmtree(temp_dir, ignore_errors=True)
 
     logging.debug('User input folder: %s', folder_to_classify)
     reset_nudity_report()

--- a/nudity-detector-deepstack.py
+++ b/nudity-detector-deepstack.py
@@ -1,115 +1,162 @@
-from datetime import datetime
-import os
-import shutil
 import logging
-import requests
-import cv2
-import json
-from nudity_detector_utils import classify_files_in_folder, save_nudity_report, nudity_report, report_lock, check_and_save_report, load_existing_report, handle_results
+import os
+import tempfile
 
-# Configure logging
+import cv2
+import requests
+
+from nudity_detector_utils import (
+    classify_files_in_folder,
+    create_session_state,
+    get_detected_results,
+    get_report_path,
+    handle_results,
+    load_existing_report,
+    make_scan_config,
+    nudity_report,
+    normalize_threshold,
+    reset_nudity_report,
+    save_nudity_report,
+)
+
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# DeepStack server configuration
-DEEPSTACK_URL = "http://localhost:5000/v1/vision/nsfw"
+DEEPSTACK_URL = 'http://localhost:5000/v1/vision/nsfw'
 
-# Load existing report to avoid reprocessing files
-existing_files = load_existing_report(os.path.join('exposed', 'nudity_report.xlsx'))
 
-def classify_image(file_path):
-    """Classify an image for nudity using DeepStack."""
-    if file_path in existing_files:
-        logging.info(f"Skipping already scanned file: {file_path}")
-        return
+def prompt_threshold_percent(default_percent=60.0):
+    raw_value = input(f'Enter detection threshold percentage [{default_percent}]: ').strip()
+    if not raw_value:
+        return default_percent
 
     try:
-        # Open the image file
-        with open(file_path, "rb") as image_file:
-            # Send the image to DeepStack for classification
-            response = requests.post(DEEPSTACK_URL, files={"image": image_file})
-        
-        if response.status_code == 200:
-            # Parse the response from DeepStack
-            result = response.json()
-            logging.debug(f"DeepStack Result for {file_path}: {result}")
-            
-            # Check if nudity is detected
-            nudity_detected = result.get("nudity", {}).get("unsafe", 0) > 0.6
-            classifiers = ["unsafe"] if nudity_detected else []
-            
-            # Handle the results (e.g., save to report, copy file if nudity detected)
-            handle_results(file_path, nudity_detected, classifiers)
-        else:
-            logging.error(f"Failed to classify image {file_path}. HTTP Status: {response.status_code}")
-    except Exception as e:
-        logging.error(f"Error classifying image {file_path}: {e}")
+        return max(0.0, min(float(raw_value), 100.0))
+    except ValueError:
+        logging.warning('Invalid threshold value. Using default %.1f%%', default_percent)
+        return default_percent
+
 
 def extract_frames(file_path, frame_rate=5):
-    """Extract frames from a video file at a specified frame rate."""
     cap = cv2.VideoCapture(file_path)
-    frames = []
+    frame_paths = []
     frame_count = 0
-
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
-            break
-        if frame_count % frame_rate == 0:
-            frame_path = f"temp_frame_{frame_count}.jpg"
-            cv2.imwrite(frame_path, frame)
-            frames.append(frame_path)
-        frame_count += 1
-
-    cap.release()
-    return frames
-
-def cleanup_frames(frames):
-    """Remove temporary frames."""
-    for frame in frames:
-        try:
-            os.remove(frame)
-        except Exception as e:
-            logging.error(f"Error removing frame {frame}: {e}")
-
-def classify_video(file_path):
-    """Classify a video for nudity using DeepStack by analyzing extracted frames."""
-    if file_path in existing_files:
-        logging.info(f"Skipping already scanned file: {file_path}")
-        return
+    temp_dir = tempfile.mkdtemp(prefix='deepstack_frames_')
 
     try:
-        frames = extract_frames(file_path, frame_rate=5)  # Analyze every 5th frame
+        while cap.isOpened():
+            ret, frame = cap.read()
+            if not ret:
+                break
+            if frame_count % frame_rate == 0:
+                frame_path = os.path.join(temp_dir, f'frame_{frame_count}.jpg')
+                cv2.imwrite(frame_path, frame)
+                frame_paths.append(frame_path)
+            frame_count += 1
+    finally:
+        cap.release()
 
-        nudity_detected = False
-        detection_results = []
+    return temp_dir, frame_paths
 
-        for frame in frames:
-            with open(frame, "rb") as image_file:
-                response = requests.post(DEEPSTACK_URL, files={"image": image_file})
-            if response.status_code == 200:
+
+if __name__ == '__main__':
+    report_path = get_report_path()
+    existing_files = load_existing_report(report_path)
+
+    folder_to_classify = input('Enter the path to the folder: ').strip()
+    threshold_percent = prompt_threshold_percent()
+    threshold_value = normalize_threshold(threshold_percent)
+    scan_config = make_scan_config(
+        source_folder=folder_to_classify,
+        model_name='deepstack',
+        threshold_percent=threshold_percent,
+        theme_mode='system',
+    )
+
+    def classify_image(file_path):
+        if file_path in existing_files:
+            logging.info('Skipping already scanned file: %s', file_path)
+            return
+
+        try:
+            with open(file_path, 'rb') as image_file:
+                response = requests.post(DEEPSTACK_URL, files={'image': image_file}, timeout=30)
+
+            if response.status_code != 200:
+                logging.error('Failed to classify image %s. HTTP status: %s', file_path, response.status_code)
+                return
+
+            result = response.json()
+            confidence_score = 0.0
+            predictions = result.get('predictions', [])
+            for pred in predictions:
+                if pred.get('label') == 'nsfw':
+                    confidence_score = float(pred.get('confidence', 0.0))
+                    break
+            handle_results(
+                file_path,
+                confidence_score >= threshold_value,
+                result,
+                confidence_score=confidence_score,
+                media_type='image',
+                model_name='deepstack',
+                threshold_percent=threshold_percent,
+            )
+        except Exception as error:
+            logging.error('Error classifying image %s: %s', file_path, error)
+
+    def classify_video(file_path):
+        if file_path in existing_files:
+            logging.info('Skipping already scanned file: %s', file_path)
+            return
+
+        temp_dir = None
+        try:
+            temp_dir, frame_paths = extract_frames(file_path, frame_rate=5)
+            frame_scores = []
+            max_confidence = 0.0
+
+            for frame_path in frame_paths:
+                with open(frame_path, 'rb') as image_file:
+                    response = requests.post(DEEPSTACK_URL, files={'image': image_file}, timeout=30)
+                if response.status_code != 200:
+                    logging.error('Failed to classify frame %s. HTTP status: %s', frame_path, response.status_code)
+                    continue
+
                 result = response.json()
-                unsafe_score = result.get("nudity", {}).get("unsafe", 0)
-                detection_results.append({"frame": frame, "unsafe_score": unsafe_score})
-                if unsafe_score > 0.6:
-                    nudity_detected = True
-            else:
-                logging.error(f"Failed to classify frame {frame}. HTTP Status: {response.status_code}")
+                confidence_score = 0.0
+                predictions = result.get('predictions', [])
+                for pred in predictions:
+                    if pred.get('label') == 'nsfw':
+                        confidence_score = float(pred.get('confidence', 0.0))
+                        break
+                max_confidence = max(max_confidence, confidence_score)
+                frame_scores.append({'frame': os.path.basename(frame_path), 'unsafe_score': confidence_score})
+                if max_confidence >= threshold_value:
+                    break
 
-        json_result = json.dumps(detection_results, ensure_ascii=False, indent=4)
-        handle_results(file_path, nudity_detected, json_result)
-        cleanup_frames(frames)
+            handle_results(
+                file_path,
+                max_confidence >= threshold_value,
+                frame_scores,
+                confidence_score=max_confidence,
+                media_type='video',
+                model_name='deepstack',
+                threshold_percent=threshold_percent,
+            )
+        except Exception as error:
+            logging.error('Error classifying video %s: %s', file_path, error)
+        finally:
+            if temp_dir and os.path.isdir(temp_dir):
+                for frame_name in os.listdir(temp_dir):
+                    frame_path = os.path.join(temp_dir, frame_name)
+                    if os.path.isfile(frame_path):
+                        os.remove(frame_path)
+                os.rmdir(temp_dir)
 
-    except Exception as e:
-        logging.error(f"Error classifying video {file_path}: {e}")
-
-if __name__ == "__main__":
-    # Get the folder path from the user
-    folder_to_classify = input("Enter the path to the folder: ").strip()
-    logging.debug(f"User input folder: {folder_to_classify}")
-    
-    # Classify files in the specified folder
+    logging.debug('User input folder: %s', folder_to_classify)
+    reset_nudity_report()
     classify_files_in_folder(folder_to_classify, classify_image, classify_video)
-    
-    # Save the nudity report
-    report_path = os.path.join('exposed', 'nudity_report.xlsx')
-    save_nudity_report(nudity_report, report_path)
+
+    session_state = create_session_state(scan_config=scan_config, results=get_detected_results(nudity_report))
+    save_nudity_report(nudity_report, report_path, session_state=session_state)
+    logging.info('Report saved to %s', report_path)

--- a/nudity-detector-nudenet.py
+++ b/nudity-detector-nudenet.py
@@ -1,12 +1,11 @@
 import json
 import logging
 import os
+import shutil
 import tempfile
 
 import cv2
 from nudenet import NudeDetector
-
-import logging
 
 from nudity_detector_utils import (
     classify_files_in_folder,
@@ -85,11 +84,7 @@ def extract_frames(file_path, frame_rate=5):
 
 def cleanup_frames(temp_dir):
     if os.path.isdir(temp_dir):
-        for file_name in os.listdir(temp_dir):
-            file_path = os.path.join(temp_dir, file_name)
-            if os.path.isfile(file_path):
-                os.remove(file_path)
-        os.rmdir(temp_dir)
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/nudity-detector-nudenet.py
+++ b/nudity-detector-nudenet.py
@@ -1,142 +1,172 @@
-import os
-import logging
 import json
-from nudenet import NudeDetector
-import cv2
-from nudity_detector_utils import classify_files_in_folder, save_nudity_report, nudity_report, load_existing_report, handle_results
+import logging
+import os
+import tempfile
 
-# Configure logging
+import cv2
+from nudenet import NudeDetector
+
+import logging
+
+from nudity_detector_utils import (
+    classify_files_in_folder,
+    create_session_state,
+    get_detected_results,
+    get_report_path,
+    handle_results,
+    load_existing_report,
+    make_scan_config,
+    nudity_report,
+    normalize_threshold,
+    reset_nudity_report,
+    save_nudity_report,
+)
+
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 
-# Classes considered as nudity
-nudity_classes = [
-    'ANUS_EXPOSED',
-    'FEMALE_BREAST_EXPOSED',
-    'FEMALE_GENITALIA_EXPOSED',
-    'MALE_GENITALIA_EXPOSED',
-    'BUTTOCKS_EXPOSED'
-]
+NUDITY_CLASSES = {
+    'EXPOSED_ANUS',
+    'EXPOSED_BREAST_F',
+    'EXPOSED_GENITALIA_F',
+    'EXPOSED_GENITALIA_M',
+    'EXPOSED_BUTTOCKS',
+}
 
-# Load existing report to avoid reprocessing files
-existing_files = load_existing_report(os.path.join('exposed', 'nudity_report.xlsx'))
 
-# Initialize the NudeDetector
-detector = NudeDetector()
-
-def classify_image(file_path):
-    """Classify an image for nudity."""
-    if file_path in existing_files:
-        logging.info(f"Skipping already scanned file: {file_path}")
-        return
+def prompt_threshold_percent(default_percent=60.0):
+    raw_value = input(f'Enter detection threshold percentage [{default_percent}]: ').strip()
+    if not raw_value:
+        return default_percent
 
     try:
-        
-        # Detect nudity in the image
-        detection_result = detector.detect(file_path)
-        logging.debug(f"Image Classification Result for {file_path}: {detection_result}")
-        
-        # Check if any detected class is considered nudity
-        nudity_detected = any(result['class'] in nudity_classes and result['score'] > 0.6 for result in detection_result)
-        
-        # Remove the 'box' property from each record for simplicity
-        detection_result = [{'class': record['class'], 'score': record['score']} for record in detection_result]
-        json_result = json.dumps(detection_result, ensure_ascii=False, indent=4)
-        logging.debug(f"Cleaned up image Classification Result for {file_path}: {json_result}")
-        
-        # Handle the results (e.g., save to report, copy file if nudity detected)
-        handle_results(file_path, nudity_detected, json_result)
-    except Exception as e:
-        logging.error(f"Error classifying image {file_path}: {e}")
+        return max(0.0, min(float(raw_value), 100.0))
+    except ValueError:
+        logging.warning('Invalid threshold value. Using default %.1f%%', default_percent)
+        return default_percent
 
-def extract_frames(file_path, frame_rate=1):
-    """Extract frames from a video file at a specified frame rate."""
+
+def simplify_nudenet_results(detection_result):
+    return [
+        {'class': record.get('label', ''), 'score': record.get('score', 0.0)}
+        for record in detection_result
+    ]
+
+
+def get_nudenet_confidence(detection_result):
+    class_scores = [
+        record.get('score', 0.0)
+        for record in detection_result
+        if record.get('label') in NUDITY_CLASSES
+    ]
+    return max(class_scores, default=0.0)
+
+
+def extract_frames(file_path, frame_rate=5):
     cap = cv2.VideoCapture(file_path)
-    frames = []
+    frame_paths = []
     frame_count = 0
+    temp_dir = tempfile.mkdtemp(prefix='nudenet_frames_')
 
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
-            break
-        # Extract frame at specific intervals
-        if frame_count % frame_rate == 0:
-            frame_path = f"temp_frame_{frame_count}.jpg"
-            cv2.imwrite(frame_path, frame)
-            frames.append(frame_path)
-        frame_count += 1
-
-    cap.release()
-    return frames
-
-def classify_video(file_path):
-    """Classify a video for nudity by analyzing extracted frames."""
     try:
+        while cap.isOpened():
+            ret, frame = cap.read()
+            if not ret:
+                break
+            if frame_count % frame_rate == 0:
+                frame_path = os.path.join(temp_dir, f'frame_{frame_count}.jpg')
+                cv2.imwrite(frame_path, frame)
+                frame_paths.append(frame_path)
+            frame_count += 1
+    finally:
+        cap.release()
+
+    return temp_dir, frame_paths
+
+
+def cleanup_frames(temp_dir):
+    if os.path.isdir(temp_dir):
+        for file_name in os.listdir(temp_dir):
+            file_path = os.path.join(temp_dir, file_name)
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+        os.rmdir(temp_dir)
+
+
+if __name__ == '__main__':
+    report_path = get_report_path()
+    existing_files = load_existing_report(report_path)
+    detector = NudeDetector()
+
+    folder_to_classify = input('Enter the path to the folder: ').strip()
+    threshold_percent = prompt_threshold_percent()
+    threshold_value = normalize_threshold(threshold_percent)
+    scan_config = make_scan_config(
+        source_folder=folder_to_classify,
+        model_name='nudenet',
+        threshold_percent=threshold_percent,
+        theme_mode='system',
+    )
+
+    def classify_image(file_path):
         if file_path in existing_files:
-            logging.info(f"Skipping already scanned file: {file_path}")
+            logging.info('Skipping already scanned file: %s', file_path)
             return
 
-        # Extract frames
-        frames = extract_frames(file_path, frame_rate=5)  # Analyze every 5th frame
-
-        detection_results = []
-        nudity_detected = False
-
-        # Analyze each frame
-        for frame in frames:
-            try:
-                if frame is None:
-                    logging.error("Extracted frame is None, skipping...")
-                    continue
-                
-                # Detect nudity in the frame
-                result = detector.detect(frame)
-                detection_results.extend(result)
-
-                # Check if any frame has nudity
-                if any(r['class'] in nudity_classes and r['score'] > 0.6 for r in result):
-                    nudity_detected = True
-                    logging.info("Nudity detected in video frame, no need to continue checking other frames...")
-                    break  # Exit the loop as we already detected nudity, no need to continue
-            except Exception as e:
-                if frame is None:
-                    logging.error(f"Error classifying frame, due to type None: {e}")
-                else:
-                    logging.error(f"Error classifying frame {frame}: {e}")
-                
-            
-        # Simplify results for the report
-        simplified_results = [
-            {'class': record['class'], 'score': record['score']}
-            for record in detection_results
-        ]
-        json_result = json.dumps(simplified_results, ensure_ascii=False, indent=4)
-
-        # Step 4: Handle results
-        handle_results(file_path, nudity_detected, json_result)
-            
-        # Cleanup frames after saving the report
-        cleanup_frames(frames)
-
-    except Exception as e:
-        logging.error(f"Error classifying video {file_path}: {e}")
-
-def cleanup_frames(frames):
-    """Remove temporary frames."""
-    for frame in frames:
         try:
-            if os.path.exists(frame):
-                os.remove(frame)
-        except Exception as e:
-            logging.error(f"Error removing frame {frame}: {e}")
+            detection_result = detector.detect(file_path)
+            confidence_score = get_nudenet_confidence(detection_result)
+            nudity_detected = confidence_score >= threshold_value
+            simplified_results = simplify_nudenet_results(detection_result)
+            handle_results(
+                file_path,
+                nudity_detected,
+                simplified_results,
+                confidence_score=confidence_score,
+                media_type='image',
+                model_name='nudenet',
+                threshold_percent=threshold_percent,
+            )
+        except Exception as error:
+            logging.error('Error classifying image %s: %s', file_path, error)
 
-if __name__ == "__main__":
-    # Get the folder path from the user
-    folder_to_classify = input("Enter the path to the folder: ").strip()
-    logging.debug(f"User input folder: {folder_to_classify}")
-    
-    # Classify files in the specified folder
+    def classify_video(file_path):
+        if file_path in existing_files:
+            logging.info('Skipping already scanned file: %s', file_path)
+            return
+
+        temp_dir = None
+        try:
+            temp_dir, frame_paths = extract_frames(file_path, frame_rate=5)
+            detection_results = []
+            max_confidence = 0.0
+
+            for frame_path in frame_paths:
+                frame_result = detector.detect(frame_path)
+                simplified_frame = simplify_nudenet_results(frame_result)
+                detection_results.append({'frame': os.path.basename(frame_path), 'detections': simplified_frame})
+                max_confidence = max(max_confidence, get_nudenet_confidence(frame_result))
+                if max_confidence >= threshold_value:
+                    break
+
+            handle_results(
+                file_path,
+                max_confidence >= threshold_value,
+                detection_results,
+                confidence_score=max_confidence,
+                media_type='video',
+                model_name='nudenet',
+                threshold_percent=threshold_percent,
+            )
+        except Exception as error:
+            logging.error('Error classifying video %s: %s', file_path, error)
+        finally:
+            if temp_dir:
+                cleanup_frames(temp_dir)
+
+    logging.debug('User input folder: %s', folder_to_classify)
+    reset_nudity_report()
     classify_files_in_folder(folder_to_classify, classify_image, classify_video)
-    
-    # Save the nudity report
-    report_path = os.path.join('exposed', 'nudity_report.xlsx')
-    save_nudity_report(nudity_report, report_path)
+
+    session_state = create_session_state(scan_config=scan_config, results=get_detected_results(nudity_report))
+    save_nudity_report(nudity_report, report_path, session_state=session_state)
+    logging.info('Report saved to %s', report_path)

--- a/nudity_detector_gui.py
+++ b/nudity_detector_gui.py
@@ -8,6 +8,7 @@ Supports both NudeNet and DeepStack models.
 import base64
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -352,9 +353,9 @@ class NudityDetectorGUI:
     def check_deepstack_server(self):
         try:
             import requests
-            requests.get('http://localhost:5000', timeout=5)
-            return True
-        except (OSError, IOError, json.JSONDecodeError):
+            response = requests.get('http://localhost:5000', timeout=5)
+            return response.ok
+        except requests.exceptions.RequestException:
             return False
 
     def start_scanning(self):
@@ -412,11 +413,7 @@ class NudityDetectorGUI:
         return temp_dir, frame_paths
 
     def cleanup_frame_dir(self, temp_dir, frame_paths):
-        for frame_path in frame_paths:
-            if os.path.exists(frame_path):
-                os.remove(frame_path)
-        if os.path.isdir(temp_dir):
-            os.rmdir(temp_dir)
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
     def create_nudenet_classifiers(self, existing_files, threshold_value, threshold_percent):
         from nudenet import NudeDetector

--- a/nudity_detector_gui.py
+++ b/nudity_detector_gui.py
@@ -5,489 +5,815 @@ A tkinter-based graphical user interface for the nudity detection system.
 Supports both NudeNet and DeepStack models.
 """
 
-import tkinter as tk
-from tkinter import ttk, filedialog, messagebox
-import threading
+import base64
+import json
 import os
 import subprocess
-import sys
-import webbrowser
-import logging
+import tempfile
+import threading
+import tkinter as tk
 from datetime import datetime
+from functools import partial
+from io import BytesIO
+from tkinter import filedialog, messagebox, ttk
 
-# Import existing functionality
-from nudity_detector_utils import classify_files_in_folder, save_nudity_report, nudity_report, load_existing_report
+import cv2
 
-# Configure logging for GUI
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+try:
+    from PIL import Image, ImageTk
+except ImportError:
+    Image = None
+    ImageTk = None
+
+from nudity_detector_utils import (
+    DEFAULT_REPORT_DIR,
+    classify_files_in_folder,
+    create_session_state,
+    delete_file_safely,
+    get_detected_results,
+    get_report_path,
+    handle_results,
+    load_report_entries,
+    load_scan_session,
+    make_scan_config,
+    nudity_report,
+    normalize_threshold,
+    open_file,
+    open_file_location,
+    replace_nudity_report,
+    reset_nudity_report,
+    save_nudity_report,
+)
+
+NUDITY_CLASSES = {
+    'EXPOSED_ANUS',
+    'EXPOSED_BREAST_F',
+    'EXPOSED_GENITALIA_F',
+    'EXPOSED_GENITALIA_M',
+    'EXPOSED_BUTTOCKS',
+}
+XLSX_EXTENSION = '.xlsx'
+NO_THUMBNAIL_TEXT = 'No thumbnail available'
+
 
 class NudityDetectorGUI:
     def __init__(self, root):
         self.root = root
-        self.root.title("Nudity Detector")
-        self.root.geometry("600x700")
-        self.root.resizable(True, True)
-        
-        # Variables
-        self.model_var = tk.StringVar(value="nudenet")
+        self.root.title('Nudity Detector')
+        self.root.geometry('1080x820')
+        self.root.minsize(900, 700)
+
+        self.style = ttk.Style()
+        self.default_theme_name = self.style.theme_use()
+
+        self.model_var = tk.StringVar(value='nudenet')
         self.folder_var = tk.StringVar()
-        self.status_var = tk.StringVar(value="Ready")
+        self.theme_var = tk.StringVar(value='system')
+        self.threshold_var = tk.DoubleVar(value=60.0)
+        self.status_var = tk.StringVar(value='Ready')
+        self.summary_var = tk.StringVar(value='No scan has been run yet.')
+
         self.is_processing = False
         self.processing_thread = None
-        
-        # Initialize GUI components
+        self.detected_results = []
+        self.last_report_path = get_report_path()
+        self.thumbnail_photo = None
+        self.thumbnail_meta_var = tk.StringVar(value='Select a result to preview.')
+
         self.create_widgets()
-        
+        self.apply_theme(self.theme_var.get())
+        self.load_initial_session()
+
     def create_widgets(self):
-        """Create and layout all GUI widgets."""
-        # Main frame
-        main_frame = ttk.Frame(self.root, padding="10")
-        main_frame.grid(row=0, column=0, sticky="nsew")
-        
-        # Configure grid weights
         self.root.columnconfigure(0, weight=1)
         self.root.rowconfigure(0, weight=1)
-        main_frame.columnconfigure(1, weight=1)
-        
-        # Title
-        title_label = ttk.Label(main_frame, text="Nudity Detector", font=("Arial", 16, "bold"))
-        title_label.grid(row=0, column=0, columnspan=3, pady=(0, 20))
-        
-        # Model selection
-        model_frame = ttk.LabelFrame(main_frame, text="Detection Model", padding="10")
-        model_frame.grid(row=1, column=0, columnspan=3, sticky="we", pady=(0, 10))
-        
-        nudenet_radio = ttk.Radiobutton(model_frame, text="NudeNet (Fast, Local)", 
-                                       variable=self.model_var, value="nudenet")
-        nudenet_radio.grid(row=0, column=0, sticky=tk.W)
-        
-        deepstack_radio = ttk.Radiobutton(model_frame, text="DeepStack (Requires server)", 
-                                         variable=self.model_var, value="deepstack")
-        deepstack_radio.grid(row=1, column=0, sticky=tk.W)
-        
-        # Folder selection
-        folder_frame = ttk.LabelFrame(main_frame, text="Folder to Scan", padding="10")
-        folder_frame.grid(row=2, column=0, columnspan=3, sticky="we", pady=(0, 10))
-        folder_frame.columnconfigure(0, weight=1)
-        
-        self.folder_entry = ttk.Entry(folder_frame, textvariable=self.folder_var, width=50)
-        self.folder_entry.grid(row=0, column=0, sticky="we", padx=(0, 10))
-        
-        browse_button = ttk.Button(folder_frame, text="Browse...", command=self.browse_folder)
-        browse_button.grid(row=0, column=1)
-        
-        # Control buttons
-        control_frame = ttk.Frame(main_frame)
-        control_frame.grid(row=3, column=0, columnspan=3, pady=(0, 20))
-        
-        self.start_button = ttk.Button(control_frame, text="Start Scanning", command=self.start_scanning)
-        self.start_button.grid(row=0, column=0, padx=(0, 10))
-        
-        self.stop_button = ttk.Button(control_frame, text="Stop", command=self.stop_scanning, state="disabled")
-        self.stop_button.grid(row=0, column=1)
-        
-        # Progress bar
-        progress_frame = ttk.LabelFrame(main_frame, text="Progress", padding="10")
-        progress_frame.grid(row=4, column=0, columnspan=3, sticky="we", pady=(0, 10))
-        progress_frame.columnconfigure(0, weight=1)
-        
-        self.progress_bar = ttk.Progressbar(progress_frame, mode='indeterminate')
-        self.progress_bar.grid(row=0, column=0, sticky="we", pady=(0, 5))
-        
-        self.status_label = ttk.Label(progress_frame, textvariable=self.status_var)
-        self.status_label.grid(row=1, column=0)
-        
-        # Results section
-        results_frame = ttk.LabelFrame(main_frame, text="Results", padding="10")
-        results_frame.grid(row=5, column=0, columnspan=3, sticky="we", pady=(0, 10))
-        
-        self.open_folder_button = ttk.Button(results_frame, text="Open Exposed Folder", 
-                                           command=self.open_exposed_folder, state="disabled")
-        self.open_folder_button.grid(row=0, column=0, padx=(0, 10))
-        
-        self.open_report_button = ttk.Button(results_frame, text="Open Report", 
-                                           command=self.open_report, state="disabled")
-        self.open_report_button.grid(row=0, column=1)
-        
-        # Log area
-        log_frame = ttk.LabelFrame(main_frame, text="Log", padding="10")
-        log_frame.grid(row=6, column=0, columnspan=3, sticky="nsew", pady=(0, 10))
+
+        main_frame = ttk.Frame(self.root, padding=16)
+        main_frame.grid(row=0, column=0, sticky='nsew')
+        main_frame.columnconfigure(0, weight=1)
+        main_frame.rowconfigure(3, weight=1)
+        main_frame.rowconfigure(4, weight=1)
+
+        header_frame = ttk.Frame(main_frame)
+        header_frame.grid(row=0, column=0, sticky='ew', pady=(0, 12))
+        header_frame.columnconfigure(0, weight=1)
+
+        ttk.Label(header_frame, text='Nudity Detector', style='Title.TLabel').grid(row=0, column=0, sticky='w')
+        ttk.Label(
+            header_frame,
+            text='Modern scan workflow with saved sessions, theme control, and post-scan review.',
+            style='Subtitle.TLabel',
+        ).grid(row=1, column=0, sticky='w', pady=(4, 0))
+
+        controls_frame = ttk.LabelFrame(main_frame, text='Scan Settings', padding=12)
+        controls_frame.grid(row=1, column=0, sticky='ew', pady=(0, 12))
+        controls_frame.columnconfigure(1, weight=1)
+        controls_frame.columnconfigure(3, weight=1)
+
+        ttk.Label(controls_frame, text='Theme').grid(row=0, column=0, sticky='w')
+        self.theme_combo = ttk.Combobox(
+            controls_frame,
+            textvariable=self.theme_var,
+            values=('system', 'light', 'dark'),
+            state='readonly',
+        )
+        self.theme_combo.grid(row=0, column=1, sticky='ew', padx=(8, 16), pady=(0, 8))
+        self.theme_combo.bind('<<ComboboxSelected>>', lambda _event: self.apply_theme(self.theme_var.get()))
+
+        ttk.Label(controls_frame, text='Model').grid(row=0, column=2, sticky='w')
+        model_frame = ttk.Frame(controls_frame)
+        model_frame.grid(row=0, column=3, sticky='w', pady=(0, 8))
+        self.nudenet_radio = ttk.Radiobutton(model_frame, text='NudeNet', variable=self.model_var, value='nudenet')
+        self.deepstack_radio = ttk.Radiobutton(model_frame, text='DeepStack', variable=self.model_var, value='deepstack')
+        self.nudenet_radio.grid(row=0, column=0, sticky='w')
+        self.deepstack_radio.grid(row=0, column=1, sticky='w', padx=(12, 0))
+
+        ttk.Label(controls_frame, text='Source Folder').grid(row=1, column=0, sticky='w')
+        self.folder_entry = ttk.Entry(controls_frame, textvariable=self.folder_var)
+        self.folder_entry.grid(row=1, column=1, columnspan=2, sticky='ew', padx=(8, 8), pady=(0, 8))
+        self.browse_button = ttk.Button(controls_frame, text='Browse...', command=self.browse_folder)
+        self.browse_button.grid(row=1, column=3, sticky='e', pady=(0, 8))
+
+        ttk.Label(controls_frame, text='Threshold %').grid(row=2, column=0, sticky='w')
+        self.threshold_spinbox = ttk.Spinbox(
+            controls_frame,
+            from_=0,
+            to=100,
+            increment=1,
+            textvariable=self.threshold_var,
+            width=8,
+        )
+        self.threshold_spinbox.grid(row=2, column=1, sticky='w', padx=(8, 16))
+        ttk.Label(controls_frame, text='Only detections at or above this confidence are treated as explicit.').grid(
+            row=2,
+            column=2,
+            columnspan=2,
+            sticky='w',
+        )
+
+        action_frame = ttk.Frame(main_frame)
+        action_frame.grid(row=2, column=0, sticky='ew', pady=(0, 12))
+        for column in range(8):
+            action_frame.columnconfigure(column, weight=1 if column == 7 else 0)
+
+        self.start_button = ttk.Button(action_frame, text='Start Scan', command=self.start_scanning)
+        self.stop_button = ttk.Button(action_frame, text='Stop', command=self.stop_scanning, state='disabled')
+        self.save_session_button = ttk.Button(action_frame, text='Save Session', command=self.save_session_dialog)
+        self.load_session_button = ttk.Button(action_frame, text='Load Session', command=self.load_session_dialog)
+        self.open_report_button = ttk.Button(action_frame, text='Open Report', command=self.open_report, state='disabled')
+        self.open_reports_button = ttk.Button(action_frame, text='Open Reports Folder', command=self.open_reports_folder)
+
+        self.start_button.grid(row=0, column=0, padx=(0, 8))
+        self.stop_button.grid(row=0, column=1, padx=(0, 8))
+        self.save_session_button.grid(row=0, column=2, padx=(0, 8))
+        self.load_session_button.grid(row=0, column=3, padx=(0, 8))
+        self.open_report_button.grid(row=0, column=4, padx=(0, 8))
+        self.open_reports_button.grid(row=0, column=5)
+
+        results_frame = ttk.LabelFrame(main_frame, text='Detected Media Review', padding=12)
+        results_frame.grid(row=3, column=0, sticky='nsew', pady=(0, 12))
+        results_frame.columnconfigure(0, weight=1)
+        results_frame.columnconfigure(2, weight=0)
+        results_frame.rowconfigure(1, weight=1)
+
+        ttk.Label(results_frame, textvariable=self.summary_var, style='Summary.TLabel').grid(row=0, column=0, sticky='w', pady=(0, 8))
+
+        columns = ('name', 'media_type', 'confidence', 'model', 'path')
+        self.results_tree = ttk.Treeview(results_frame, columns=columns, show='headings', height=12)
+        self.results_tree.heading('name', text='File')
+        self.results_tree.heading('media_type', text='Type')
+        self.results_tree.heading('confidence', text='Confidence')
+        self.results_tree.heading('model', text='Model')
+        self.results_tree.heading('path', text='Path')
+        self.results_tree.column('name', width=220, anchor='w')
+        self.results_tree.column('media_type', width=90, anchor='center')
+        self.results_tree.column('confidence', width=110, anchor='center')
+        self.results_tree.column('model', width=100, anchor='center')
+        self.results_tree.column('path', width=430, anchor='w')
+        self.results_tree.grid(row=1, column=0, sticky='nsew')
+
+        tree_scroll = ttk.Scrollbar(results_frame, orient='vertical', command=self.results_tree.yview)
+        tree_scroll.grid(row=1, column=1, sticky='ns')
+        self.results_tree.configure(yscrollcommand=tree_scroll.set)
+        self.results_tree.bind('<<TreeviewSelect>>', self.on_result_selected)
+
+        preview_frame = ttk.Frame(results_frame)
+        preview_frame.grid(row=1, column=2, rowspan=2, sticky='ns', padx=(12, 0))
+        preview_frame.columnconfigure(0, weight=1)
+
+        ttk.Label(preview_frame, text='Thumbnail Preview').grid(row=0, column=0, sticky='w', pady=(0, 8))
+        self.thumbnail_image_label = ttk.Label(
+            preview_frame,
+            text=NO_THUMBNAIL_TEXT,
+            anchor='center',
+            width=30,
+        )
+        self.thumbnail_image_label.grid(row=1, column=0, sticky='n', pady=(0, 8))
+        ttk.Label(preview_frame, textvariable=self.thumbnail_meta_var, wraplength=220, justify='left').grid(
+            row=2,
+            column=0,
+            sticky='w',
+        )
+
+        result_action_frame = ttk.Frame(results_frame)
+        result_action_frame.grid(row=2, column=0, sticky='w', pady=(10, 0))
+        self.open_file_button = ttk.Button(
+            result_action_frame,
+            text='Open File',
+            command=self.open_selected_file,
+            state='disabled',
+        )
+        self.open_location_button = ttk.Button(
+            result_action_frame,
+            text='Open Location',
+            command=self.open_selected_location,
+            state='disabled',
+        )
+        self.delete_button = ttk.Button(
+            result_action_frame,
+            text='Delete Selected',
+            command=self.delete_selected_result,
+            state='disabled',
+        )
+        self.open_file_button.grid(row=0, column=0, padx=(0, 8))
+        self.open_location_button.grid(row=0, column=1, padx=(0, 8))
+        self.delete_button.grid(row=0, column=2)
+
+        log_frame = ttk.LabelFrame(main_frame, text='Activity Log', padding=12)
+        log_frame.grid(row=4, column=0, sticky='nsew')
         log_frame.columnconfigure(0, weight=1)
         log_frame.rowconfigure(0, weight=1)
-        main_frame.rowconfigure(6, weight=1)
-        
-        # Create text widget with scrollbar
-        self.log_text = tk.Text(log_frame, height=8, wrap=tk.WORD)
-        scrollbar = ttk.Scrollbar(log_frame, orient="vertical", command=self.log_text.yview)
-        self.log_text.configure(yscrollcommand=scrollbar.set)
-        
-        self.log_text.grid(row=0, column=0, sticky="nsew")
-        scrollbar.grid(row=0, column=1, sticky="ns")
-        
+
+        self.log_text = tk.Text(log_frame, height=10, wrap=tk.WORD, relief='flat', borderwidth=0)
+        self.log_text.grid(row=0, column=0, sticky='nsew')
+        log_scroll = ttk.Scrollbar(log_frame, orient='vertical', command=self.log_text.yview)
+        log_scroll.grid(row=0, column=1, sticky='ns')
+        self.log_text.configure(yscrollcommand=log_scroll.set)
+
+        footer_frame = ttk.Frame(main_frame)
+        footer_frame.grid(row=5, column=0, sticky='ew', pady=(12, 0))
+        footer_frame.columnconfigure(0, weight=1)
+        self.progress_bar = ttk.Progressbar(footer_frame, mode='indeterminate')
+        self.progress_bar.grid(row=0, column=0, sticky='ew', padx=(0, 12))
+        ttk.Label(footer_frame, textvariable=self.status_var).grid(row=0, column=1, sticky='e')
+
+    def load_initial_session(self):
+        if os.path.exists(self.last_report_path):
+            try:
+                self.load_session_from_path(self.last_report_path, show_feedback=False)
+            except (OSError, IOError, json.JSONDecodeError):
+                self.log_message('No previous session was loaded from the default report path.')
+
+    def build_scan_config(self):
+        return make_scan_config(
+            source_folder=self.folder_var.get().strip(),
+            model_name=self.model_var.get(),
+            threshold_percent=int(round(self.threshold_var.get())),
+            theme_mode=self.theme_var.get(),
+        )
+
+    def build_session_state(self):
+        return create_session_state(scan_config=self.build_scan_config(), results=list(self.detected_results))
+
     def browse_folder(self):
-        """Open folder selection dialog."""
-        folder = filedialog.askdirectory(title="Select folder to scan")
+        folder = filedialog.askdirectory(title='Select folder to scan')
         if folder:
             self.folder_var.set(folder)
-            
+
     def log_message(self, message):
-        """Add message to log display."""
-        timestamp = datetime.now().strftime("%H:%M:%S")
-        log_entry = f"[{timestamp}] {message}\n"
-        self.log_text.insert(tk.END, log_entry)
+        timestamp = datetime.now().strftime('%H:%M:%S')
+        self.log_text.insert(tk.END, f'[{timestamp}] {message}\n')
         self.log_text.see(tk.END)
         self.root.update_idletasks()
-        
-    def start_scanning(self):
-        """Start the nudity detection process."""
-        folder_path = self.folder_var.get().strip()
-        
-        if not folder_path:
-            messagebox.showerror("Error", "Please select a folder to scan.")
-            return
-            
-        if not os.path.exists(folder_path):
-            messagebox.showerror("Error", "Selected folder does not exist.")
-            return
-            
-        model = self.model_var.get()
-        
-        # Check DeepStack availability if selected
-        if model == "deepstack":
-            if not self.check_deepstack_server():
-                messagebox.showerror("Error", 
-                    "DeepStack server is not available at http://localhost:5000\n"
-                    "Please start the DeepStack server using docker-compose up")
-                return
-        
-        # Update UI state
-        self.is_processing = True
-        self.start_button.config(state="disabled")
-        self.stop_button.config(state="normal")
-        self.open_folder_button.config(state="disabled")
-        self.open_report_button.config(state="disabled")
-        self.progress_bar.start(10)
-        self.status_var.set("Initializing...")
-        
-        # Clear log
-        self.log_text.delete(1.0, tk.END)
-        self.log_message(f"Starting scan with {model.upper()} model")
-        self.log_message(f"Scanning folder: {folder_path}")
-        
-        # Start processing in separate thread
-        self.processing_thread = threading.Thread(target=self.process_files, args=(folder_path, model))
-        self.processing_thread.daemon = True
-        self.processing_thread.start()
-        
-    def stop_scanning(self):
-        """Stop the scanning process."""
-        self.is_processing = False
-        self.status_var.set("Stopping...")
-        self.log_message("Stop requested by user")
-        
+
+    def apply_theme(self, theme_mode):
+        palette = {
+            'system': {
+                'frame': '#f4f1ea',
+                'panel': '#ffffff',
+                'text': '#1f2328',
+                'muted': '#5c6670',
+                'accent': '#1b6a63',
+                'border': '#d7ddd7',
+                'log': '#ffffff',
+            },
+            'light': {
+                'frame': '#f8f3eb',
+                'panel': '#fffdfa',
+                'text': '#1c262b',
+                'muted': '#51606a',
+                'accent': '#0f766e',
+                'border': '#d9dfd6',
+                'log': '#fffdfa',
+            },
+            'dark': {
+                'frame': '#182026',
+                'panel': '#1f2a30',
+                'text': '#f3f6f4',
+                'muted': '#b6c4c5',
+                'accent': '#7ed6cb',
+                'border': '#334047',
+                'log': '#11181d',
+            },
+        }
+        colors = palette.get(theme_mode, palette['system'])
+
+        self.style.theme_use(self.default_theme_name)
+        self.root.configure(background=colors['frame'])
+        self.style.configure('TFrame', background=colors['frame'])
+        self.style.configure('TLabelframe', background=colors['panel'], bordercolor=colors['border'])
+        self.style.configure('TLabelframe.Label', background=colors['panel'], foreground=colors['text'])
+        self.style.configure('TLabel', background=colors['frame'], foreground=colors['text'])
+        self.style.configure('Title.TLabel', font=('Georgia', 20, 'bold'), foreground=colors['text'])
+        self.style.configure('Subtitle.TLabel', foreground=colors['muted'])
+        self.style.configure('Summary.TLabel', background=colors['panel'], foreground=colors['muted'])
+        self.style.configure('TButton', padding=8)
+        self.style.configure('Treeview', background=colors['panel'], foreground=colors['text'], fieldbackground=colors['panel'])
+        self.style.configure('Treeview.Heading', background=colors['accent'], foreground=colors['panel'])
+        self.style.map('Treeview', background=[('selected', colors['accent'])], foreground=[('selected', colors['panel'])])
+        self.log_text.configure(
+            background=colors['log'],
+            foreground=colors['text'],
+            insertbackground=colors['text'],
+            selectbackground=colors['accent'],
+        )
+
+    def set_controls_for_processing(self, processing):
+        state = 'disabled' if processing else 'normal'
+        self.start_button.config(state='disabled' if processing else 'normal')
+        self.stop_button.config(state='normal' if processing else 'disabled')
+        self.browse_button.config(state=state)
+        self.folder_entry.config(state=state)
+        self.theme_combo.config(state='disabled' if processing else 'readonly')
+        self.threshold_spinbox.config(state=state)
+        self.nudenet_radio.config(state=state)
+        self.deepstack_radio.config(state=state)
+
     def check_deepstack_server(self):
-        """Check if DeepStack server is running."""
         try:
             import requests
-            response = requests.get("http://localhost:5000", timeout=5)
+            requests.get('http://localhost:5000', timeout=5)
             return True
-        except:
+        except (OSError, IOError, json.JSONDecodeError):
             return False
-            
-    def process_files(self, folder_path, model):
-        """Process files in the background thread."""
+
+    def start_scanning(self):
+        folder_path = self.folder_var.get().strip()
+        if not folder_path:
+            messagebox.showerror('Error', 'Please select a folder to scan.')
+            return
+        if not os.path.isdir(folder_path):
+            messagebox.showerror('Error', 'Selected folder does not exist.')
+            return
+        if self.model_var.get() == 'deepstack' and not self.check_deepstack_server():
+            messagebox.showerror(
+                'Error',
+                'DeepStack server is not available at http://localhost:5000\nPlease start it before scanning.',
+            )
+            return
+
+        self.is_processing = True
+        self.detected_results = []
+        self.populate_results([])
+        reset_nudity_report()
+        self.log_text.delete('1.0', tk.END)
+        self.set_controls_for_processing(True)
+        self.progress_bar.start(10)
+        self.status_var.set('Scanning...')
+        self.summary_var.set('Scan running...')
+        self.log_message(f"Starting {self.model_var.get()} scan at {self.threshold_var.get():.0f}% threshold")
+        self.log_message(f'Source folder: {folder_path}')
+
+        self.processing_thread = threading.Thread(target=self.process_files, args=(folder_path,), daemon=True)
+        self.processing_thread.start()
+
+    def stop_scanning(self):
+        self.is_processing = False
+        self.status_var.set('Stopping...')
+        self.log_message('Stop requested. Pending files will be skipped as workers drain.')
+
+    def extract_video_frames(self, file_path, temp_prefix):
+        temp_dir = tempfile.mkdtemp(prefix=temp_prefix)
+        frame_paths = []
+        cap = cv2.VideoCapture(file_path)
+        frame_count = 0
         try:
-            # Clear previous report data
-            global nudity_report
-            nudity_report.clear()
-            
-            self.status_var.set("Loading model...")
-            
-            # Import and initialize based on selected model
-            if model == "nudenet":
-                from nudenet import NudeDetector
-                import json
-                
-                detector = NudeDetector()
-                nudity_classes = [
-                    'ANUS_EXPOSED', 'FEMALE_BREAST_EXPOSED', 'FEMALE_GENITALIA_EXPOSED',
-                    'MALE_GENITALIA_EXPOSED', 'BUTTOCKS_EXPOSED'
-                ]
-                
-                def classify_image(file_path):
-                    if not self.is_processing:
-                        return
-                        
-                    self.root.after(0, lambda: self.log_message(f"Processing: {os.path.basename(file_path)}"))
-                    
-                    try:
-                        detection_result = detector.detect(file_path)
-                        nudity_detected = any(result['class'] in nudity_classes and result['score'] > 0.6 
-                                            for result in detection_result)
-                        
-                        detection_result = [{'class': record['class'], 'score': record['score']} 
-                                          for record in detection_result]
-                        json_result = json.dumps(detection_result, ensure_ascii=False, indent=4)
-                        
-                        # Handle results using existing utility
-                        from nudity_detector_utils import handle_results
-                        handle_results(file_path, nudity_detected, json_result)
-                        
-                    except Exception as e:
-                        self.root.after(0, lambda: self.log_message(f"Error processing {file_path}: {e}"))
-                
-                def classify_video(file_path):
-                    if not self.is_processing:
-                        return
-                        
-                    self.root.after(0, lambda: self.log_message(f"Processing video: {os.path.basename(file_path)}"))
-                    
-                    try:
-                        import cv2
-                        
-                        # Extract frames
-                        cap = cv2.VideoCapture(file_path)
-                        frames = []
-                        frame_count = 0
-                        
-                        while cap.isOpened() and self.is_processing:
-                            ret, frame = cap.read()
-                            if not ret:
-                                break
-                            if frame_count % 5 == 0:  # Every 5th frame
-                                frame_path = f"temp_frame_{frame_count}.jpg"
-                                cv2.imwrite(frame_path, frame)
-                                frames.append(frame_path)
-                            frame_count += 1
-                        
-                        cap.release()
-                        
-                        detection_results = []
-                        nudity_detected = False
-                        
-                        for frame in frames:
-                            if not self.is_processing:
-                                break
-                                
-                            try:
-                                result = detector.detect(frame)
-                                detection_results.extend(result)
-                                
-                                if any(r['class'] in nudity_classes and r['score'] > 0.6 for r in result):
-                                    nudity_detected = True
-                                    break
-                            except Exception as e:
-                                self.root.after(0, lambda: self.log_message(f"Error processing frame: {e}"))
-                        
-                        # Cleanup frames
-                        for frame in frames:
-                            try:
-                                if os.path.exists(frame):
-                                    os.remove(frame)
-                            except:
-                                pass
-                        
-                        simplified_results = [{'class': record['class'], 'score': record['score']}
-                                            for record in detection_results]
-                        json_result = json.dumps(simplified_results, ensure_ascii=False, indent=4)
-                        
-                        from nudity_detector_utils import handle_results
-                        handle_results(file_path, nudity_detected, json_result)
-                        
-                    except Exception as e:
-                        self.root.after(0, lambda: self.log_message(f"Error processing video {file_path}: {e}"))
-                        
-            else:  # deepstack
-                import requests
-                import cv2
-                import json
-                
-                DEEPSTACK_URL = "http://localhost:5000/v1/vision/nsfw"
-                
-                def classify_image(file_path):
-                    if not self.is_processing:
-                        return
-                        
-                    self.root.after(0, lambda: self.log_message(f"Processing: {os.path.basename(file_path)}"))
-                    
-                    try:
-                        with open(file_path, "rb") as image_file:
-                            response = requests.post(DEEPSTACK_URL, files={"image": image_file})
-                        
-                        if response.status_code == 200:
-                            result = response.json()
-                            nudity_detected = result.get("nudity", {}).get("unsafe", 0) > 0.6
-                            classifiers = ["unsafe"] if nudity_detected else []
-                            
-                            from nudity_detector_utils import handle_results
-                            handle_results(file_path, nudity_detected, classifiers)
-                        else:
-                            self.root.after(0, lambda: self.log_message(f"Failed to classify {file_path}"))
-                            
-                    except Exception as e:
-                        self.root.after(0, lambda: self.log_message(f"Error processing {file_path}: {e}"))
-                
-                def classify_video(file_path):
-                    if not self.is_processing:
-                        return
-                        
-                    self.root.after(0, lambda: self.log_message(f"Processing video: {os.path.basename(file_path)}"))
-                    
-                    try:
-                        # Similar video processing as NudeNet but with DeepStack API
-                        cap = cv2.VideoCapture(file_path)
-                        frames = []
-                        frame_count = 0
-                        
-                        while cap.isOpened() and self.is_processing:
-                            ret, frame = cap.read()
-                            if not ret:
-                                break
-                            if frame_count % 5 == 0:
-                                frame_path = f"temp_frame_{frame_count}.jpg"
-                                cv2.imwrite(frame_path, frame)
-                                frames.append(frame_path)
-                            frame_count += 1
-                        
-                        cap.release()
-                        
-                        nudity_detected = False
-                        detection_results = []
-                        
-                        for frame in frames:
-                            if not self.is_processing:
-                                break
-                                
-                            try:
-                                with open(frame, "rb") as image_file:
-                                    response = requests.post(DEEPSTACK_URL, files={"image": image_file})
-                                
-                                if response.status_code == 200:
-                                    result = response.json()
-                                    unsafe_score = result.get("nudity", {}).get("unsafe", 0)
-                                    detection_results.append({"frame": frame, "unsafe_score": unsafe_score})
-                                    
-                                    if unsafe_score > 0.6:
-                                        nudity_detected = True
-                                        break
-                            except Exception as e:
-                                self.root.after(0, lambda: self.log_message(f"Error processing frame: {e}"))
-                        
-                        # Cleanup frames
-                        for frame in frames:
-                            try:
-                                if os.path.exists(frame):
-                                    os.remove(frame)
-                            except:
-                                pass
-                        
-                        json_result = json.dumps(detection_results, ensure_ascii=False, indent=4)
-                        from nudity_detector_utils import handle_results
-                        handle_results(file_path, nudity_detected, json_result)
-                        
-                    except Exception as e:
-                        self.root.after(0, lambda: self.log_message(f"Error processing video {file_path}: {e}"))
-            
-            # Load existing report to avoid reprocessing
-            existing_files = load_existing_report(os.path.join('exposed', 'nudity_report.xlsx'))
-            
-            self.status_var.set("Scanning files...")
-            
-            # Process all files
-            classify_files_in_folder(folder_path, classify_image, classify_video)
-            
-            # Save final report
-            if self.is_processing:
-                self.status_var.set("Saving report...")
-                report_path = os.path.join('exposed', 'nudity_report.xlsx')
-                save_nudity_report(nudity_report, report_path)
-                
-                self.root.after(0, lambda: self.log_message(f"Scan completed! Report saved to: {report_path}"))
-                self.root.after(0, lambda: self.log_message(f"Files processed: {len(nudity_report)}"))
-                
-                # Count detected files
-                detected_count = sum(1 for entry in nudity_report if entry.get('nudity_detected', False))
-                self.root.after(0, lambda: self.log_message(f"Nudity detected in: {detected_count} files"))
-                
-        except Exception as e:
-            self.root.after(0, lambda: self.log_message(f"Error during processing: {e}"))
-            
+            while cap.isOpened() and self.is_processing:
+                ret, frame = cap.read()
+                if not ret:
+                    break
+                if frame_count % 5 == 0:
+                    frame_path = os.path.join(temp_dir, f'frame_{frame_count}.jpg')
+                    cv2.imwrite(frame_path, frame)
+                    frame_paths.append(frame_path)
+                frame_count += 1
         finally:
-            # Update UI state
+            cap.release()
+        return temp_dir, frame_paths
+
+    def cleanup_frame_dir(self, temp_dir, frame_paths):
+        for frame_path in frame_paths:
+            if os.path.exists(frame_path):
+                os.remove(frame_path)
+        if os.path.isdir(temp_dir):
+            os.rmdir(temp_dir)
+
+    def create_nudenet_classifiers(self, existing_files, threshold_value, threshold_percent):
+        from nudenet import NudeDetector
+
+        detector = NudeDetector()
+
+        def simplify_results(detection_result):
+            return [
+                {'class': record.get('label', ''), 'score': record.get('score', 0.0)}
+                for record in detection_result
+            ]
+
+        def confidence_for_results(detection_result):
+            class_scores = [
+                record.get('score', 0.0)
+                for record in detection_result
+                if record.get('label') in NUDITY_CLASSES
+            ]
+            return max(class_scores, default=0.0)
+
+        def classify_image(file_path):
+            if not self.is_processing or file_path in existing_files:
+                return
+            self.root.after(0, lambda: self.log_message(f'Processing image: {os.path.basename(file_path)}'))
+            detection_result = detector.detect(file_path)
+            confidence_score = confidence_for_results(detection_result)
+            handle_results(
+                file_path,
+                confidence_score >= threshold_value,
+                simplify_results(detection_result),
+                confidence_score=confidence_score,
+                media_type='image',
+                model_name='nudenet',
+                threshold_percent=threshold_percent,
+            )
+
+        def classify_video(file_path):
+            if not self.is_processing or file_path in existing_files:
+                return
+            self.root.after(0, lambda: self.log_message(f'Processing video: {os.path.basename(file_path)}'))
+            temp_dir, frame_paths = self.extract_video_frames(file_path, 'gui_nudenet_frames_')
+            try:
+                detection_results = []
+                max_confidence = 0.0
+                for frame_path in frame_paths:
+                    if not self.is_processing:
+                        break
+                    frame_result = detector.detect(frame_path)
+                    simplified_frame = simplify_results(frame_result)
+                    detection_results.append({'frame': os.path.basename(frame_path), 'detections': simplified_frame})
+                    max_confidence = max(max_confidence, confidence_for_results(frame_result))
+                    if max_confidence >= threshold_value:
+                        break
+
+                handle_results(
+                    file_path,
+                    max_confidence >= threshold_value,
+                    detection_results,
+                    confidence_score=max_confidence,
+                    media_type='video',
+                    model_name='nudenet',
+                    threshold_percent=threshold_percent,
+                )
+            finally:
+                self.cleanup_frame_dir(temp_dir, frame_paths)
+
+        return classify_image, classify_video
+
+    def request_deepstack_score(self, image_path, requests_module, deepstack_url):
+        with open(image_path, 'rb') as image_file:
+            response = requests_module.post(deepstack_url, files={'image': image_file}, timeout=30)
+        if response.status_code != 200:
+            return None
+        result = response.json()
+        confidence_score = 0.0
+        predictions = result.get('predictions', [])
+        for pred in predictions:
+            if pred.get('label') == 'nsfw':
+                confidence_score = float(pred.get('confidence', 0.0))
+                break
+        return result, confidence_score
+
+    def run_deepstack_image(self, file_path, existing_files, threshold_value, threshold_percent, requests_module, deepstack_url):
+        if not self.is_processing or file_path in existing_files:
+            return
+        self.root.after(0, lambda: self.log_message(f'Processing image: {os.path.basename(file_path)}'))
+        scored_result = self.request_deepstack_score(file_path, requests_module, deepstack_url)
+        if scored_result is None:
+            self.root.after(0, lambda: self.log_message(f'Failed to classify {file_path}'))
+            return
+        result, confidence_score = scored_result
+        handle_results(
+            file_path,
+            confidence_score >= threshold_value,
+            result,
+            confidence_score=confidence_score,
+            media_type='image',
+            model_name='deepstack',
+            threshold_percent=threshold_percent,
+        )
+
+    def run_deepstack_video(self, file_path, existing_files, threshold_value, threshold_percent, requests_module, deepstack_url):
+        if not self.is_processing or file_path in existing_files:
+            return
+        self.root.after(0, lambda: self.log_message(f'Processing video: {os.path.basename(file_path)}'))
+        temp_dir, frame_paths = self.extract_video_frames(file_path, 'gui_deepstack_frames_')
+        try:
+            frame_scores = []
+            max_confidence = 0.0
+            for frame_path in frame_paths:
+                if not self.is_processing:
+                    break
+                scored_result = self.request_deepstack_score(frame_path, requests_module, deepstack_url)
+                if scored_result is None:
+                    continue
+                _result, confidence_score = scored_result
+                frame_scores.append({'frame': os.path.basename(frame_path), 'unsafe_score': confidence_score})
+                max_confidence = max(max_confidence, confidence_score)
+                if max_confidence >= threshold_value:
+                    break
+
+            handle_results(
+                file_path,
+                max_confidence >= threshold_value,
+                frame_scores,
+                confidence_score=max_confidence,
+                media_type='video',
+                model_name='deepstack',
+                threshold_percent=threshold_percent,
+            )
+        finally:
+            self.cleanup_frame_dir(temp_dir, frame_paths)
+
+    def create_deepstack_classifiers(self, existing_files, threshold_value, threshold_percent):
+        import requests
+
+        deepstack_url = 'http://localhost:5000/v1/vision/nsfw'
+        return (
+            partial(self.run_deepstack_image, existing_files=existing_files, threshold_value=threshold_value, threshold_percent=threshold_percent, requests_module=requests, deepstack_url=deepstack_url),
+            partial(self.run_deepstack_video, existing_files=existing_files, threshold_value=threshold_value, threshold_percent=threshold_percent, requests_module=requests, deepstack_url=deepstack_url),
+        )
+
+    def process_files(self, folder_path):
+        model_name = self.model_var.get()
+        threshold_percent = self.threshold_var.get()
+        threshold_value = normalize_threshold(threshold_percent)
+        report_path = get_report_path()
+        existing_files = {entry.get('file') for entry in load_report_entries(report_path)}
+
+        try:
+            if model_name == 'nudenet':
+                classify_image, classify_video = self.create_nudenet_classifiers(
+                    existing_files,
+                    threshold_value,
+                    threshold_percent,
+                )
+            else:
+                classify_image, classify_video = self.create_deepstack_classifiers(
+                    existing_files,
+                    threshold_value,
+                    threshold_percent,
+                )
+
+            classify_files_in_folder(folder_path, classify_image, classify_video)
+
+            self.detected_results = get_detected_results(nudity_report)
+            self.last_report_path = report_path
+            session_state = self.build_session_state()
+            save_nudity_report(nudity_report, report_path, session_state=session_state)
+            self.root.after(0, lambda: self.populate_results(self.detected_results))
+            self.root.after(0, lambda: self.log_message(f'Scan complete. {len(self.detected_results)} detections listed.'))
+        except Exception as error:
+            error_message = str(error)
+            self.root.after(0, lambda: self.log_message(f'Error during processing: {error_message}'))
+        finally:
             self.root.after(0, self.finish_processing)
-            
+
     def finish_processing(self):
-        """Clean up after processing is complete."""
         self.is_processing = False
         self.progress_bar.stop()
-        self.start_button.config(state="normal")
-        self.stop_button.config(state="disabled")
-        
-        # Enable result buttons if exposed folder exists
-        if os.path.exists('exposed'):
-            self.open_folder_button.config(state="normal")
-            if os.path.exists(os.path.join('exposed', 'nudity_report.xlsx')):
-                self.open_report_button.config(state="normal")
-        
-        self.status_var.set("Ready")
-        
-    def open_exposed_folder(self):
-        """Open the exposed folder in file manager."""
-        exposed_path = os.path.abspath('exposed')
-        if os.path.exists(exposed_path):
-            try:
-                if sys.platform == "win32":
-                    os.startfile(exposed_path)
-                elif sys.platform == "darwin":
-                    subprocess.run(["open", exposed_path])
-                else:
-                    subprocess.run(["xdg-open", exposed_path])
-            except Exception as e:
-                messagebox.showerror("Error", f"Could not open folder: {e}")
+        self.status_var.set('Ready')
+        self.set_controls_for_processing(False)
+        self.update_result_action_state()
+        self.open_report_button.config(state='normal' if os.path.exists(self.last_report_path) else 'disabled')
+
+    def populate_results(self, results):
+        for item_id in self.results_tree.get_children():
+            self.results_tree.delete(item_id)
+
+        for index, entry in enumerate(results):
+            self.results_tree.insert(
+                '',
+                'end',
+                iid=str(index),
+                values=(
+                    os.path.basename(entry.get('file', '')),
+                    entry.get('media_type', 'unknown'),
+                    f"{float(entry.get('confidence_percent', 0)):.2f}%",
+                    entry.get('model_name', ''),
+                    entry.get('file', ''),
+                ),
+            )
+
+        if results:
+            self.summary_var.set(f'{len(results)} explicit item(s) detected. Review actions are available below.')
         else:
-            messagebox.showwarning("Warning", "Exposed folder does not exist yet.")
-            
+            self.summary_var.set('No explicit media detected in the current session.')
+        self.update_result_action_state()
+        self.clear_thumbnail_preview()
+
+    def on_result_selected(self, _event=None):
+        self.update_result_action_state()
+        self.update_thumbnail_preview()
+
+    def update_result_action_state(self):
+        has_selection = bool(self.results_tree.selection())
+        state = 'normal' if has_selection and not self.is_processing else 'disabled'
+        self.open_file_button.config(state=state)
+        self.open_location_button.config(state=state)
+        self.delete_button.config(state=state)
+
+    def clear_thumbnail_preview(self):
+        self.thumbnail_photo = None
+        self.thumbnail_image_label.config(image='', text=NO_THUMBNAIL_TEXT)
+        self.thumbnail_meta_var.set('Select a result to preview.')
+
+    def update_thumbnail_preview(self):
+        _index, entry = self.get_selected_entry()
+        if entry is None:
+            self.clear_thumbnail_preview()
+            return
+
+        thumbnail_b64 = entry.get('thumbnail', '') or ''
+        meta_text = (
+            f"Type: {entry.get('media_type', 'unknown')}\n"
+            f"Confidence: {entry.get('confidence_percent', 0):.2f}%\n"
+            f"Model: {entry.get('model_name', '')}"
+        )
+
+        if not thumbnail_b64 or Image is None or ImageTk is None:
+            self.thumbnail_photo = None
+            self.thumbnail_image_label.config(image='', text=NO_THUMBNAIL_TEXT)
+            self.thumbnail_meta_var.set(meta_text)
+            return
+
+        try:
+            thumbnail_bytes = base64.b64decode(thumbnail_b64)
+            with Image.open(BytesIO(thumbnail_bytes)) as pil_image:
+                if hasattr(Image, 'Resampling'):
+                    pil_image.thumbnail((220, 220), Image.Resampling.LANCZOS)
+                else:
+                    pil_image.thumbnail((220, 220))
+                self.thumbnail_photo = ImageTk.PhotoImage(pil_image)
+
+            self.thumbnail_image_label.config(image=self.thumbnail_photo, text='')
+            self.thumbnail_meta_var.set(meta_text)
+        except Exception:
+            self.thumbnail_photo = None
+            self.thumbnail_image_label.config(image='', text='Thumbnail unavailable')
+            self.thumbnail_meta_var.set(meta_text)
+
+    def get_selected_entry(self):
+        selection = self.results_tree.selection()
+        if not selection:
+            return None, None
+        index = int(selection[0])
+        if index >= len(self.detected_results):
+            return None, None
+        return index, self.detected_results[index]
+
+    def open_selected_file(self):
+        """Open the selected detected file directly."""
+        _index, entry = self.get_selected_entry()
+        if entry is None:
+            return
+        file_path = entry.get('file', '')
+        if not os.path.exists(file_path):
+            messagebox.showerror('Error', f'File no longer exists: {file_path}')
+            return
+        success, error_message = open_file(file_path)
+        if not success:
+            messagebox.showerror('Error', f'Could not open file: {error_message}')
+
+    def open_selected_location(self):
+        _index, entry = self.get_selected_entry()
+        if entry is None:
+            return
+        success, error_message = open_file_location(entry.get('file', ''))
+        if not success:
+            messagebox.showerror('Error', f'Could not open location: {error_message}')
+
+    def delete_selected_result(self):
+        index, entry = self.get_selected_entry()
+        if entry is None or index is None:
+            return
+
+        confirm = messagebox.askyesno(
+            'Delete detected file',
+            f"Move this file to trash if possible?\n\n{entry.get('file', '')}",
+        )
+        if not confirm:
+            return
+
+        success, message = delete_file_safely(entry.get('file', ''))
+        if not success:
+            messagebox.showerror('Delete failed', message)
+            return
+
+        # Note: With new schema, detected files are not copied to the reports folder.
+        # They remain at original location. No cleanup of copies needed.
+
+        del self.detected_results[index]
+        remaining_entries = [item for item in nudity_report if item.get('file') != entry.get('file')]
+        replace_nudity_report(remaining_entries)
+        save_nudity_report(nudity_report, self.last_report_path, session_state=self.build_session_state())
+        self.populate_results(self.detected_results)
+        self.log_message(f"Deleted {entry.get('file', '')}. {message}")
+
+    def save_session_dialog(self):
+        report_path = filedialog.asksaveasfilename(
+            title='Save scan report',
+            defaultextension=XLSX_EXTENSION,
+            filetypes=[('Excel Report', f'*{XLSX_EXTENSION}')],
+            initialfile=os.path.basename(self.last_report_path),
+        )
+        if not report_path:
+            return
+
+        self.last_report_path = report_path
+        save_nudity_report(nudity_report, report_path, session_state=self.build_session_state())
+        self.open_report_button.config(state='normal')
+        self.log_message(f'Saved session report to {report_path}')
+
+    def load_session_dialog(self):
+        file_path = filedialog.askopenfilename(
+            title='Load saved session',
+            filetypes=[('Report or Session', f'*{XLSX_EXTENSION} *.json'), ('Excel Report', f'*{XLSX_EXTENSION}'), ('JSON Session', '*.json')],
+        )
+        if file_path:
+            self.load_session_from_path(file_path, show_feedback=True)
+
+    def load_session_from_path(self, file_path, show_feedback):
+        session_state = load_scan_session(file_path)
+        report_path = file_path if file_path.endswith(XLSX_EXTENSION) else file_path.replace('_session.json', XLSX_EXTENSION)
+        report_entries = load_report_entries(report_path) if os.path.exists(report_path) else []
+        detected_results = session_state.get('results') or get_detected_results(report_entries)
+        scan_config = session_state.get('scan_config', {})
+
+        self.folder_var.set(scan_config.get('source_folder', ''))
+        self.model_var.set(scan_config.get('model_name', 'nudenet'))
+        self.theme_var.set(scan_config.get('theme_mode', 'system'))
+        self.threshold_var.set(float(scan_config.get('threshold_percent', 60)))
+        self.apply_theme(self.theme_var.get())
+
+        self.detected_results = detected_results
+        replace_nudity_report(report_entries or detected_results)
+        self.populate_results(self.detected_results)
+        self.last_report_path = report_path
+        self.open_report_button.config(state='normal' if os.path.exists(report_path) else 'disabled')
+
+        if show_feedback:
+            self.log_message(f'Loaded session from {file_path}')
+
+    def open_reports_folder(self):
+        success, error_message = open_file_location(DEFAULT_REPORT_DIR)
+        if not success:
+            messagebox.showerror('Error', f'Could not open folder: {error_message}')
+
     def open_report(self):
-        """Open the nudity report."""
-        report_path = os.path.abspath(os.path.join('exposed', 'nudity_report.xlsx'))
-        if os.path.exists(report_path):
-            try:
-                if sys.platform == "win32":
-                    os.startfile(report_path)
-                elif sys.platform == "darwin":
-                    subprocess.run(["open", report_path])
-                else:
-                    subprocess.run(["xdg-open", report_path])
-            except Exception as e:
-                messagebox.showerror("Error", f"Could not open report: {e}")
-        else:
-            messagebox.showwarning("Warning", "Report file does not exist yet.")
+        if not os.path.exists(self.last_report_path):
+            messagebox.showwarning('Warning', 'No report has been saved yet.')
+            return
+        try:
+            if os.name == 'nt':
+                os.startfile(self.last_report_path)
+            elif os.uname().sysname == 'Darwin':
+                subprocess.run(['open', self.last_report_path], check=False)
+            else:
+                subprocess.run(['xdg-open', self.last_report_path], check=False)
+        except Exception as error:
+            messagebox.showerror('Error', f'Could not open report: {error}')
+
 
 def main():
-    """Main entry point for the GUI application."""
     root = tk.Tk()
     app = NudityDetectorGUI(root)
-    
-    # Handle window closing
+
     def on_closing():
         if app.is_processing:
-            if messagebox.askokcancel("Quit", "Scanning is in progress. Do you want to quit?"):
-                app.is_processing = False
-                root.destroy()
-        else:
-            root.destroy()
-    
-    root.protocol("WM_DELETE_WINDOW", on_closing)
-    
-    # Center window on screen
-    root.update_idletasks()
-    width = root.winfo_width()
-    height = root.winfo_height()
-    x = (root.winfo_screenwidth() // 2) - (width // 2)
-    y = (root.winfo_screenheight() // 2) - (height // 2)
-    root.geometry(f"{width}x{height}+{x}+{y}")
-    
+            if not messagebox.askokcancel('Quit', 'Scanning is in progress. Do you want to quit?'):
+                return
+            app.is_processing = False
+        root.destroy()
+
+    root.protocol('WM_DELETE_WINDOW', on_closing)
     root.mainloop()
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     main()

--- a/nudity_detector_utils.py
+++ b/nudity_detector_utils.py
@@ -27,7 +27,7 @@ import subprocess
 import sys
 from datetime import datetime
 from io import BytesIO
-from queue import Queue
+from queue import Empty, Queue
 from threading import Lock, Thread
 from typing import Optional, Tuple
 
@@ -177,6 +177,10 @@ def generate_video_thumbnail(file_path: str, size: Tuple[int, int] = (100, 100))
     if cv2 is None:
         logging.debug('OpenCV not available for video thumbnail generation: %s', file_path)
         return None
+
+    if Image is None:
+        logging.debug('PIL not available for video thumbnail generation: %s', file_path)
+        return None
         
     try:
         cap = cv2.VideoCapture(file_path)
@@ -277,7 +281,7 @@ def detect_with_timeout(detector, file_path: str, timeout_seconds: int = 60) -> 
         timeout_seconds: Timeout in seconds
         
     Returns:
-        Detection results or None if timeout
+        Detection results when detection completes successfully
         
     Raises:
         TimeoutError: If detection exceeds timeout
@@ -293,7 +297,7 @@ def detect_with_timeout(detector, file_path: str, timeout_seconds: int = 60) -> 
         except Exception as e:
             exception_container[0] = e
     
-    thread = Thread(target=run_detection, daemon=False)
+    thread = Thread(target=run_detection, daemon=True)
     thread.start()
     thread.join(timeout=timeout_seconds)
     
@@ -436,8 +440,11 @@ def process_file_queue(file_queue, classify_image, classify_video):
         classify_image: Image classification function
         classify_video: Video classification function
     """
-    while not file_queue.empty():
-        file_path = file_queue.get()
+    while True:
+        try:
+            file_path = file_queue.get_nowait()
+        except Empty:
+            break
         try:
             process_file(file_path, classify_image, classify_video)
         except Exception as e:
@@ -609,6 +616,7 @@ def save_nudity_report(report_data, file_path, session_state=None):
 def check_and_save_report(report_data, file_path, batch_size=500, session_state=None):
     if len(report_data) >= batch_size:
         save_nudity_report(report_data, file_path, session_state=session_state)
+        report_data.clear()
 
 
 def _sheet_headers(sheet):

--- a/nudity_detector_utils.py
+++ b/nudity_detector_utils.py
@@ -1,21 +1,423 @@
+"""Nudity detection utility functions.
+
+This module provides utilities for:
+- Image and video file classification using AI models (NudeNet, DeepStack)
+- Thumbnail generation (base64-encoded) for detected items
+- Report generation and persistence (Excel, JSON)
+- Thread-safe batch processing with worker pools
+- Timeout protection for long-running detections
+
+Thread Safety:
+- nudity_report list is protected by report_lock
+- Worker threads are non-daemon to ensure proper cleanup
+- All thread operations have explicit join() with timeout
+
+Schema:
+- Report entries include: file, media_type, model_name, confidence, nudity_detected, 
+  detected_classes, thumbnail, date_classified
+- Thumbnails are stored as base64-encoded PNG strings for portability
+"""
+
+import base64
+import json
+import logging
 import os
 import shutil
-import logging
-from queue import Queue
-from threading import Thread, Lock
-import openpyxl
+import subprocess
+import sys
 from datetime import datetime
+from io import BytesIO
+from queue import Queue
+from threading import Lock, Thread
+from typing import Optional, Tuple
 
-# Supported formats
+import openpyxl
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+try:
+    import cv2
+except ImportError:
+    cv2 = None
+
+try:
+    from send2trash import send2trash
+except ImportError:
+    send2trash = None
+
+
+
+
+def validate_report_dir(report_dir: str) -> Tuple[bool, str]:
+    """Validate report directory is writable and safe.
+    
+    Args:
+        report_dir: Path to report directory
+        
+    Returns:
+        Tuple of (valid: bool, error_message: str)
+    """
+    if not report_dir:
+        return False, 'Report directory cannot be empty'
+    
+    # Prevent writing to system directories
+    if report_dir in ['/', '/etc', '/sys', '/dev', '/proc', '/root']:
+        return False, f'Cannot write reports to system directory: {report_dir}'
+    
+    try:
+        os.makedirs(report_dir, exist_ok=True)
+        # Try to write a test file
+        test_file = os.path.join(report_dir, '.test')
+        with open(test_file, 'w') as f:
+            f.write('test')
+        os.remove(test_file)
+        return True, ''
+    except (OSError, IOError) as e:
+        return False, f'Report directory not writable: {e}'
+
 image_extensions = {'.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.tiff'}
 video_extensions = {'.mp4', '.avi', '.mkv', '.mov', '.vob', '.wmv', '.flv', '.3gp', '.webm'}
+REPORT_HEADERS = [
+    'File',
+    'Media Type',
+    'Model',
+    'Threshold Percent',
+    'Confidence Percent',
+    'Nudity Detected',
+    'Detected Classes',
+    'Thumbnail',
+    'Date Classified',
+]
+SESSION_VERSION = 1
+DEFAULT_REPORT_DIR = 'reports'
 
-# Global variables
 nudity_report = []
 report_lock = Lock()
 
+
+def get_report_path(report_dir=DEFAULT_REPORT_DIR):
+    return os.path.join(report_dir, 'nudity_report.xlsx')
+
+
+def get_session_path(report_file_path):
+    base_name, _ = os.path.splitext(report_file_path)
+    return f'{base_name}_session.json'
+
+
+def normalize_threshold(threshold_value):
+    if threshold_value is None:
+        return 0.6
+
+    threshold = float(threshold_value)
+    if threshold > 1:
+        threshold /= 100.0
+    return max(0.0, min(threshold, 1.0))
+
+
+def threshold_to_percent(threshold_value):
+    return round(normalize_threshold(threshold_value) * 100, 2)
+
+
+def detect_media_type(file_path):
+    _, ext = os.path.splitext(file_path)
+    ext = ext.lower()
+    if ext in image_extensions:
+        return 'image'
+    if ext in video_extensions:
+        return 'video'
+    return 'unknown'
+
+
+
+def generate_image_thumbnail(file_path: str, size: Tuple[int, int] = (100, 100)) -> Optional[str]:
+    """Generate base64-encoded thumbnail from image file.
+    
+    Args:
+        file_path: Path to image file
+        size: Thumbnail size as (width, height) tuple
+        
+    Returns:
+        Base64-encoded PNG thumbnail string, or None if generation fails
+    """
+    if Image is None:
+        logging.debug('PIL not available for thumbnail generation: %s', file_path)
+        return None
+        
+    try:
+        with Image.open(file_path) as img:
+            img.thumbnail(size, Image.Resampling.LANCZOS)
+            # Convert to RGB if needed (e.g., RGBA or grayscale)
+            if img.mode != 'RGB':
+                img = img.convert('RGB')
+            
+            # Encode to base64
+            buffer = BytesIO()
+            img.save(buffer, format='PNG')
+            buffer.seek(0)
+            encoded = base64.b64encode(buffer.getvalue()).decode('utf-8')
+            return encoded
+    except Exception as e:
+        logging.warning('Failed to generate image thumbnail for %s: %s', file_path, e)
+        return None
+
+
+def generate_video_thumbnail(file_path: str, size: Tuple[int, int] = (100, 100)) -> Optional[str]:
+    """Generate base64-encoded thumbnail from video file at 25% progress.
+    
+    Args:
+        file_path: Path to video file
+        size: Thumbnail size as (width, height) tuple
+        
+    Returns:
+        Base64-encoded PNG thumbnail string, or None if generation fails
+    """
+    if cv2 is None:
+        logging.debug('OpenCV not available for video thumbnail generation: %s', file_path)
+        return None
+        
+    try:
+        cap = cv2.VideoCapture(file_path)
+        if not cap.isOpened():
+            logging.warning('Could not open video file: %s', file_path)
+            return None
+            
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        if total_frames <= 0:
+            logging.warning('Video has no frames: %s', file_path)
+            cap.release()
+            return None
+        
+        # Extract frame at 25% progress
+        frame_index = max(0, int(total_frames * 0.25))
+        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+        
+        ret, frame = cap.read()
+        cap.release()
+        
+        if not ret or frame is None:
+            logging.warning('Could not extract frame from video: %s', file_path)
+            return None
+        
+        # Convert BGR to RGB and create thumbnail
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        img = Image.fromarray(frame_rgb)
+        img.thumbnail(size, Image.Resampling.LANCZOS)
+        
+        # Encode to base64
+        buffer = BytesIO()
+        img.save(buffer, format='PNG')
+        buffer.seek(0)
+        encoded = base64.b64encode(buffer.getvalue()).decode('utf-8')
+        return encoded
+    except Exception as e:
+        logging.warning('Failed to generate video thumbnail for %s: %s', file_path, e)
+        return None
+
+
+def get_thumbnail(file_path: str, media_type: Optional[str] = None) -> Optional[str]:
+    """Get thumbnail for image or video file.
+    
+    Args:
+        file_path: Path to media file
+        media_type: 'image' or 'video', auto-detected if None
+        
+    Returns:
+        Base64-encoded thumbnail or None if unavailable
+    """
+    if not os.path.exists(file_path):
+        return None
+        
+    media_type = media_type or detect_media_type(file_path)
+    
+    if media_type == 'image':
+        return generate_image_thumbnail(file_path)
+    elif media_type == 'video':
+        return generate_video_thumbnail(file_path)
+    
+    return None
+
+
+def open_file(file_path: str) -> Tuple[bool, str]:
+    """Open file directly (not parent directory).
+    
+    Args:
+        file_path: Path to file to open
+        
+    Returns:
+        Tuple of (success: bool, error_message: str)
+    """
+    if not os.path.exists(file_path):
+        error_msg = f'File does not exist: {file_path}'
+        logging.warning(error_msg)
+        return False, error_msg
+    
+    try:
+        if sys.platform == 'win32':
+            os.startfile(file_path)
+        elif sys.platform == 'darwin':
+            subprocess.run(['open', file_path], check=False)
+        else:
+            subprocess.run(['xdg-open', file_path], check=False)
+        return True, ''
+    except Exception as error:
+        error_msg = f'Could not open file {file_path}: {error}'
+        logging.error(error_msg)
+        return False, error_msg
+
+
+def detect_with_timeout(detector, file_path: str, timeout_seconds: int = 60) -> Optional[list]:
+    """Wrap NudeNet detection with timeout.
+    
+    Args:
+        detector: NudeNet detector instance  
+        file_path: Path to media file
+        timeout_seconds: Timeout in seconds
+        
+    Returns:
+        Detection results or None if timeout
+        
+    Raises:
+        TimeoutError: If detection exceeds timeout
+    """
+    from threading import Timer
+    
+    result_container = [None]
+    exception_container = [None]
+    
+    def run_detection():
+        try:
+            result_container[0] = detector.detect(file_path)
+        except Exception as e:
+            exception_container[0] = e
+    
+    thread = Thread(target=run_detection, daemon=False)
+    thread.start()
+    thread.join(timeout=timeout_seconds)
+    
+    if thread.is_alive():
+        logging.error('Detection timeout for file: %s after %d seconds', file_path, timeout_seconds)
+        raise TimeoutError(f'Detection timeout for {file_path}')
+    
+    if exception_container[0]:
+        raise exception_container[0]
+    
+    return result_container[0]
+
+def make_scan_config(source_folder='', model_name='nudenet', threshold_percent=60, theme_mode='system'):
+    return {
+        'theme_mode': theme_mode,
+        'source_folder': source_folder,
+        'model_name': model_name,
+        'threshold_percent': threshold_to_percent(threshold_percent),
+    }
+
+
+def create_session_state(scan_config=None, results=None):
+    return {
+        'version': SESSION_VERSION,
+        'saved_at': datetime.now().isoformat(timespec='seconds'),
+        'scan_config': scan_config or make_scan_config(),
+        'results': results or [],
+    }
+
+
+def reset_nudity_report():
+    with report_lock:
+        nudity_report.clear()
+
+
+def replace_nudity_report(entries):
+    with report_lock:
+        nudity_report.clear()
+        nudity_report.extend(entries)
+
+
+def get_detected_results(report_data=None):
+    data = report_data if report_data is not None else nudity_report
+    return [entry for entry in data if entry.get('nudity_detected')]
+
+
+def parse_detected_classes(raw_result):
+    if raw_result is None:
+        return []
+
+    parsed_result = raw_result
+    if isinstance(raw_result, str):
+        try:
+            parsed_result = json.loads(raw_result)
+        except json.JSONDecodeError:
+            parsed_result = raw_result
+
+    if isinstance(parsed_result, list):
+        labels = []
+        for item in parsed_result:
+            if isinstance(item, dict):
+                label = item.get('class') or item.get('label') or item.get('frame') or item.get('name')
+                if label:
+                    labels.append(str(label))
+            elif item:
+                labels.append(str(item))
+        return labels
+
+    if isinstance(parsed_result, dict):
+        return [str(key) for key, value in parsed_result.items() if value]
+
+    if parsed_result:
+        return [str(parsed_result)]
+    return []
+
+
+def serialize_detected_classes(raw_result):
+    if raw_result is None:
+        return '[]'
+    if isinstance(raw_result, str):
+        return raw_result
+    return json.dumps(raw_result, ensure_ascii=False, indent=2)
+
+
+def create_report_entry(
+    file_path,
+    nudity_detected,
+    raw_result,
+    confidence_score=0.0,
+    media_type=None,
+    model_name='',
+    threshold_percent=60,
+    thumbnail=None,
+):
+    """Create a report entry for a classified file.
+    
+    Args:
+        file_path: Path to classified file
+        nudity_detected: Whether nudity was detected
+        raw_result: Raw detection result (classes/predictions)
+        confidence_score: Confidence score (0-1)
+        media_type: 'image', 'video', or None (auto-detected)
+        model_name: Name of detection model used
+        threshold_percent: Threshold used for detection
+        thumbnail: Base64-encoded thumbnail or None
+        
+    Returns:
+        Dictionary containing report entry data
+    """
+    normalized_confidence = max(0.0, min(float(confidence_score or 0.0), 1.0))
+    return {
+        'file': file_path,
+        'media_type': media_type or detect_media_type(file_path),
+        'model_name': model_name,
+        'threshold_percent': threshold_to_percent(threshold_percent),
+        'confidence_percent': round(normalized_confidence * 100, 2),
+        'nudity_detected': bool(nudity_detected),
+        'detected_classes': serialize_detected_classes(raw_result),
+        'thumbnail': thumbnail or '',
+        'date_classified': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+    }
+
+
 def process_file(file_path, classify_image, classify_video):
-    """Process a single file for nudity detection."""
     _, ext = os.path.splitext(file_path)
     ext = ext.lower()
     if ext in image_extensions:
@@ -23,83 +425,380 @@ def process_file(file_path, classify_image, classify_video):
     elif ext in video_extensions:
         classify_video(file_path)
     else:
-        logging.info(f"Skipping unsupported file: {file_path}")
+        logging.info('Skipping unsupported file: %s', file_path)
+
 
 def process_file_queue(file_queue, classify_image, classify_video):
-    """Process files from the queue using the provided classification functions."""
+    """Worker thread: process files from queue.
+    
+    Args:
+        file_queue: Queue of file paths
+        classify_image: Image classification function
+        classify_video: Video classification function
+    """
     while not file_queue.empty():
         file_path = file_queue.get()
-        process_file(file_path, classify_image, classify_video)
-        file_queue.task_done()
+        try:
+            process_file(file_path, classify_image, classify_video)
+        except Exception as e:
+            logging.error('Error processing file %s: %s', file_path, e)
+        finally:
+            file_queue.task_done()
+
 
 def classify_files_in_folder(folder_path, classify_image, classify_video):
-    """Classify all files in the specified folder for nudity."""
-    logging.debug(f"Starting classification in folder: {folder_path}")
-    file_queue = Queue()
-    os.makedirs('exposed', exist_ok=True)
+    """Classify all supported files in folder using worker threads.
     
-    # Add all files in the folder to the queue
-    for root, dirs, files in os.walk(folder_path):
+    Args:
+        folder_path: Root folder to scan
+        classify_image: Image classification function
+        classify_video: Video classification function
+    """
+    logging.debug('Starting classification in folder: %s', folder_path)
+    file_queue = Queue()
+    os.makedirs(DEFAULT_REPORT_DIR, exist_ok=True)
+
+    for root, _, files in os.walk(folder_path):
         for file_name in files:
             file_queue.put(os.path.join(root, file_name))
-    
-    # Start a few worker threads to process the files
-    for _ in range(10):  # Number of threads
-        worker = Thread(target=process_file_queue, args=(file_queue, classify_image, classify_video))
-        worker.start()
-    file_queue.join()
 
-def save_nudity_report(report_data, file_path):
-    """Save the nudity detection report to an Excel file."""
-    if not report_data:
-        logging.warning("No data available to save in the report.")
+    # Create non-daemon worker threads for proper resource cleanup
+    workers = []
+    for _ in range(10):
+        worker = Thread(target=process_file_queue, args=(file_queue, classify_image, classify_video), daemon=False)
+        worker.start()
+        workers.append(worker)
+    
+    # Wait for all items to be processed
+    file_queue.join()
+    
+    # Wait for all workers to complete with timeout
+    for worker in workers:
+        worker.join(timeout=5)
+        if worker.is_alive():
+            logging.warning('Worker thread did not complete within timeout')
+
+
+def _write_report_rows(sheet, report_data):
+    """Write report data rows to Excel sheet.
+    
+    Args:
+        sheet: openpyxl worksheet
+        report_data: List of report entry dictionaries
+    """
+    sheet.delete_rows(1, sheet.max_row or 1)
+    sheet.append(REPORT_HEADERS)
+    for data in report_data:
+        sheet.append([
+            data.get('file', ''),
+            data.get('media_type', detect_media_type(data.get('file', ''))),
+            data.get('model_name', ''),
+            data.get('threshold_percent', 60),
+            data.get('confidence_percent', 0),
+            data.get('nudity_detected', False),
+            data.get('detected_classes', '[]'),
+            data.get('thumbnail', ''),
+            data.get('date_classified', ''),
+        ])
+
+
+def save_scan_session(session_state, file_path):
+    os.makedirs(os.path.dirname(file_path) or '.', exist_ok=True)
+    with open(file_path, 'w', encoding='utf-8') as session_file:
+        json.dump(session_state, session_file, ensure_ascii=False, indent=2)
+
+
+def _embed_thumbnails_in_sheet(sheet, report_data):
+    """Embed thumbnail images into report sheet thumbnail column.
+    
+    Args:
+        sheet: openpyxl worksheet
+        report_data: List of report entry dictionaries with thumbnail data
+    """
+    try:
+        from openpyxl.drawing.image import Image as XLImage
+    except ImportError:
+        logging.debug('Could not import openpyxl Image; thumbnails will not be embedded in Excel')
         return
     
+    if Image is None:
+        logging.debug('PIL not available; thumbnails will not be embedded in Excel')
+        return
+    
+    # Find Thumbnail column index
+    headers = [cell.value for cell in sheet[1]]
+    if 'Thumbnail' not in headers:
+        logging.warning('Thumbnail column not found in report sheet')
+        return
+    
+    thumbnail_col_idx = headers.index('Thumbnail') + 1  # Excel is 1-indexed
+    thumbnail_col = openpyxl.utils.get_column_letter(thumbnail_col_idx)
+    
+    # Set column width and row height for thumbnails
+    sheet.column_dimensions[thumbnail_col].width = 15
+    
+    # Embed thumbnails in rows
+    for row_idx, entry in enumerate(report_data, start=2):  # Start at row 2 (after header)
+        thumbnail_b64 = entry.get('thumbnail', '')
+        if not thumbnail_b64:
+            continue
+        
+        try:
+            # Decode base64 to bytes
+            thumbnail_data = base64.b64decode(thumbnail_b64)
+            
+            # Create PIL image and save to BytesIO
+            img = Image.open(BytesIO(thumbnail_data))
+            
+            # Save to temporary BytesIO for openpyxl
+            img_bytes = BytesIO()
+            img.save(img_bytes, format='PNG')
+            img_bytes.seek(0)
+            
+            # Insert image into cell
+            cell_ref = f'{thumbnail_col}{row_idx}'
+            xl_image = XLImage(img_bytes)
+            xl_image.width = 100
+            xl_image.height = 100
+            sheet.add_image(xl_image, cell_ref)
+            
+            # Adjust row height to fit image
+            sheet.row_dimensions[row_idx].height = 105
+            
+        except Exception as e:
+            logging.warning('Failed to embed thumbnail in cell %s: %s', cell_ref, e)
+            continue
+
+
+def save_nudity_report(report_data, file_path, session_state=None):
+    """Save report to Excel file with embedded thumbnails.
+    
+    Args:
+        report_data: List of report entry dictionaries  
+        file_path: Path to save Excel report
+        session_state: Session metadata (auto-created if None)
+    """
+    os.makedirs(os.path.dirname(file_path) or '.', exist_ok=True)
+
     if os.path.exists(file_path):
         workbook = openpyxl.load_workbook(file_path)
         sheet = workbook.active
     else:
         workbook = openpyxl.Workbook()
         sheet = workbook.active
-        sheet.title = "Nudity Report"
-        headers = ["File", "Nudity Detected", "Detected Classes", "Date Classified"]
-        sheet.append(headers)
+        sheet.title = 'Nudity Report'
 
-    # Write data rows
-    for data in report_data:
-        sheet.append([data["file"], data["nudity_detected"], data["detected_classes"], data["date_classified"]])
+    _write_report_rows(sheet, report_data)
+    _embed_thumbnails_in_sheet(sheet, report_data)
 
+    if 'Session' not in workbook.sheetnames:
+        workbook.create_sheet('Session')
+    session_sheet = workbook['Session']
+    session_sheet.delete_rows(1, session_sheet.max_row or 1)
+
+    if session_state is None:
+        session_state = create_session_state(results=get_detected_results(report_data))
+
+    session_sheet['A1'] = json.dumps(session_state, ensure_ascii=False, indent=2)
     workbook.save(file_path)
-    logging.info(f"Report saved to {file_path}")
 
-def check_and_save_report(report_data, file_path, batch_size=500):
-    """Check the report size and save it if it reaches the batch size."""
+    save_scan_session(session_state, get_session_path(file_path))
+    logging.info('Report saved to %s', file_path)
+
+
+def check_and_save_report(report_data, file_path, batch_size=500, session_state=None):
     if len(report_data) >= batch_size:
-        save_nudity_report(report_data, file_path)
-        report_data.clear()
+        save_nudity_report(report_data, file_path, session_state=session_state)
+
+
+def _sheet_headers(sheet):
+    return [cell.value for cell in next(sheet.iter_rows(min_row=1, max_row=1))]
+
+
+def _legacy_row_to_entry(row):
+    """Convert legacy report row to new report entry format.
+    
+    Args:
+        row: Legacy report row tuple
+        
+    Returns:
+        Report entry dictionary with new schema
+    """
+    detected_classes = row[2] if len(row) > 2 else '[]'
+    return {
+        'file': row[0],
+        'media_type': detect_media_type(row[0] or ''),
+        'model_name': '',
+        'threshold_percent': 60,
+        'confidence_percent': 0,
+        'nudity_detected': bool(row[1]),
+        'detected_classes': detected_classes or '[]',
+        'thumbnail': '',
+        'date_classified': row[3] if len(row) > 3 else '',
+    }
+
+
+def load_report_entries(file_path):
+    if not os.path.exists(file_path):
+        return []
+
+    workbook = openpyxl.load_workbook(file_path)
+    sheet = workbook.active
+    headers = _sheet_headers(sheet)
+    normalized_headers = {str(header).strip(): index for index, header in enumerate(headers) if header}
+    uses_new_schema = set(REPORT_HEADERS).issubset(set(normalized_headers))
+    entries = []
+
+    for row in sheet.iter_rows(min_row=2, values_only=True):
+        if not row or not row[0]:
+            continue
+
+        if uses_new_schema:
+            # Handle both old schema (Copied File) and new schema (Thumbnail)
+            thumbnail_value = ''
+            if 'Thumbnail' in normalized_headers:
+                thumbnail_value = row[normalized_headers['Thumbnail']] or ''
+            elif 'Copied File' in normalized_headers:
+                # Migration from old schema: use empty thumbnail
+                thumbnail_value = ''
+            
+            entry = {
+                'file': row[normalized_headers['File']],
+                'media_type': row[normalized_headers['Media Type']] or detect_media_type(row[normalized_headers['File']]),
+                'model_name': row[normalized_headers['Model']] or '',
+                'threshold_percent': row[normalized_headers['Threshold Percent']] or 60,
+                'confidence_percent': row[normalized_headers['Confidence Percent']] or 0,
+                'nudity_detected': bool(row[normalized_headers['Nudity Detected']]),
+                'detected_classes': row[normalized_headers['Detected Classes']] or '[]',
+                'thumbnail': thumbnail_value,
+                'date_classified': row[normalized_headers['Date Classified']] or '',
+            }
+        else:
+            entry = _legacy_row_to_entry(row)
+
+        entries.append(entry)
+
+    return entries
+
 
 def load_existing_report(file_path):
-    """Load existing report to avoid reprocessing files."""
-    existing_files = set()
+    return {entry.get('file') for entry in load_report_entries(file_path)}
+
+
+def load_scan_session(file_path):
+    session_path = file_path if file_path.endswith('.json') else get_session_path(file_path)
+    if os.path.exists(session_path):
+        with open(session_path, 'r', encoding='utf-8') as session_file:
+            return json.load(session_file)
+
     if os.path.exists(file_path):
         workbook = openpyxl.load_workbook(file_path)
-        sheet = workbook.active
-        for row in sheet.iter_rows(min_row=2, values_only=True):
-            existing_files.add(row[0])
-    return existing_files
+        if 'Session' in workbook.sheetnames:
+            raw_session = workbook['Session']['A1'].value
+            if raw_session:
+                try:
+                    return json.loads(raw_session)
+                except json.JSONDecodeError:
+                    logging.warning('Could not parse embedded session state from %s', file_path)
 
-def handle_results(file_path, nudity_detected, json_result):
-    """Handle the results of the nudity detection."""
+        return create_session_state(results=get_detected_results(load_report_entries(file_path)))
+
+    return create_session_state()
+
+
+def handle_results(
+    file_path,
+    nudity_detected,
+    raw_result,
+    confidence_score=0.0,
+    media_type=None,
+    model_name='',
+    threshold_percent=60,
+    report_dir=DEFAULT_REPORT_DIR,
+):
+    """Handle detection results: create report entry and generate thumbnail.
+    
+    No longer copies files to report_dir. Files remain at original location.
+    Thumbnails are generated for detected items (if dependencies available).
+    
+    Args:
+        file_path: Original file path
+        nudity_detected: Whether nudity was detected
+        raw_result: Raw detection result
+        confidence_score: Confidence score (0-1)
+        media_type: Media type ('image'/'video'/None)
+        model_name: Detection model name
+        threshold_percent: Detection threshold
+        report_dir: Directory for reports (not file copies)
+        
+    Returns:
+        Report entry dictionary
+    """
+    # Generate thumbnail for detected items
+    thumbnail = ''
+    if nudity_detected:
+        media_type = media_type or detect_media_type(file_path)
+        thumbnail = get_thumbnail(file_path, media_type) or ''
+    
+    # Ensure report directory exists
+    if nudity_detected:
+        os.makedirs(report_dir, exist_ok=True)
+
     with report_lock:
-        report_entry = {
-            "file": file_path,
-            "nudity_detected": nudity_detected,
-            "detected_classes": json_result,
-            "date_classified": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        }
-        
-        if nudity_detected:
-            shutil.copy(file_path, os.path.join('exposed', os.path.basename(file_path)))
-        
+        report_entry = create_report_entry(
+            file_path,
+            nudity_detected,
+            raw_result,
+            confidence_score=confidence_score,
+            media_type=media_type,
+            model_name=model_name,
+            threshold_percent=threshold_percent,
+            thumbnail=thumbnail,
+        )
         nudity_report.append(report_entry)
-        check_and_save_report(nudity_report, os.path.join('exposed', 'nudity_report.xlsx'))
+        check_and_save_report(nudity_report, get_report_path(report_dir))
+        return report_entry
+
+
+def remove_report_entry(file_path):
+    with report_lock:
+        original_length = len(nudity_report)
+        nudity_report[:] = [entry for entry in nudity_report if entry.get('file') != file_path]
+        return len(nudity_report) != original_length
+
+
+def delete_file_safely(file_path):
+    if not os.path.exists(file_path):
+        return False, 'File does not exist.'
+
+    try:
+        if send2trash is not None:
+            send2trash(file_path)
+            return True, 'Moved to trash.'
+
+        if os.path.isdir(file_path):
+            shutil.rmtree(file_path)
+        else:
+            os.remove(file_path)
+        return True, 'Deleted permanently because trash support is unavailable.'
+    except Exception as error:
+        logging.error('Could not delete %s: %s', file_path, error)
+        return False, str(error)
+
+
+def open_file_location(file_path):
+    target_path = file_path if os.path.isdir(file_path) else os.path.dirname(file_path)
+    if not target_path:
+        target_path = '.'
+
+    try:
+        if sys.platform == 'win32':
+            os.startfile(target_path)
+        elif sys.platform == 'darwin':
+            subprocess.run(['open', target_path], check=False)
+        else:
+            subprocess.run(['xdg-open', target_path], check=False)
+        return True, ''
+    except Exception as error:
+        logging.error('Could not open path %s: %s', target_path, error)
+        return False, str(error)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,7 @@
 nudenet
 vnudenet
 openpyxl
+Pillow
+opencv-python
 requests
+Send2Trash


### PR DESCRIPTION
This pull request introduces new prompt files and updates documentation to support an experimental OpenSpec workflow, including proposing, applying, archiving, and exploring changes. It also refines instructions for running and testing the NudeNet CLI, updating folder names and dependencies for clarity and accuracy.

**OpenSpec Experimental Workflow Prompts:**

* Added `/opsx:propose` prompt for proposing new changes, guiding users through artifact creation (proposal, design, tasks) with strong guardrails and clear output summaries. (.github/prompts/opsx-propose.prompt.md)
* Added `/opsx:apply` prompt for implementing tasks from an OpenSpec change, including dynamic task selection, progress tracking, and robust handling of ambiguous or blocked states. (.github/prompts/opsx-apply.prompt.md)
* Added `/opsx:archive` prompt to archive completed changes, with checks for incomplete artifacts or tasks, delta spec synchronization, and user confirmation flows. (.github/prompts/opsx-archive.prompt.md)
* Added `/opsx:explore` prompt to enable a non-implementing, discovery-focused mode for brainstorming, codebase investigation, and requirements clarification, with explicit guardrails against code changes. (.github/prompts/opsx-explore.prompt.md)

**Documentation and Dependency Updates:**

* Updated `.github/copilot-instructions.md` to clarify test scenario steps, change output directories from `exposed/` to `reports/`, and add new dependencies (`Pillow`, `opencv-python`, `Send2Trash`) for image/video processing and safe file deletion. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L139-R155) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L178-R180) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R207-R210)

These changes collectively enhance the developer workflow for OpenSpec-driven projects and improve clarity in running and testing the NudeNet CLI.