### PR TITLE
Feature: add scan progress update interval configuration and UI support

### DIFF
--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -184,3 +184,8 @@ TREEVIEW_Heading_BACKGROUND = 'accent'
 TREEVIEW_Heading_FOREGROUND = 'panel'
 TREEVIEW_SELECTED_BACKGROUND = 'accent'
 TREEVIEW_SELECTED_FOREGROUND = 'panel'
+
+# ============================================================================
+# Scan Progress
+# ============================================================================
+SCAN_PROGRESS_UPDATE_INTERVAL = 100  # Flush UI results every N files processed

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -50,7 +50,10 @@ class NudityDetectorWindow(
         self._folder = cfg.get('last_source_folder', '')
         self._theme_mode = cfg.get('theme', constants.THEME_SYSTEM)
         self._threshold = float(cfg.get('threshold_percent', constants.DEFAULT_THRESHOLD_PERCENT))
-        self._progress_interval = int(cfg.get('progress_update_interval', constants.SCAN_PROGRESS_UPDATE_INTERVAL))
+        try:
+            self._progress_interval = max(1, int(cfg.get('progress_update_interval', constants.SCAN_PROGRESS_UPDATE_INTERVAL)))
+        except (ValueError, TypeError):
+            self._progress_interval = constants.SCAN_PROGRESS_UPDATE_INTERVAL
 
         self.is_processing = False
         self.processing_thread = None

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -50,6 +50,7 @@ class NudityDetectorWindow(
         self._folder = cfg.get('last_source_folder', '')
         self._theme_mode = cfg.get('theme', constants.THEME_SYSTEM)
         self._threshold = float(cfg.get('threshold_percent', constants.DEFAULT_THRESHOLD_PERCENT))
+        self._progress_interval = int(cfg.get('progress_update_interval', constants.SCAN_PROGRESS_UPDATE_INTERVAL))
 
         self.is_processing = False
         self.processing_thread = None
@@ -203,6 +204,30 @@ class NudityDetectorWindow(
         threshold_help.set_wrap(True)
         threshold_help.set_hexpand(True)
         grid.attach(threshold_help, 2, 2, 2, 1)
+
+        # Progress update interval row
+        interval_label = Gtk.Label(label='Update Every')
+        interval_label.set_xalign(0)
+        grid.attach(interval_label, 0, 3, 1, 1)
+
+        interval_adj = Gtk.Adjustment(
+            value=self._progress_interval,
+            lower=1,
+            upper=10000,
+            step_increment=10,
+            page_increment=100,
+        )
+        self.progress_interval_spin = Gtk.SpinButton(adjustment=interval_adj, climb_rate=1, digits=0)
+        grid.attach(self.progress_interval_spin, 1, 3, 1, 1)
+
+        interval_help = Gtk.Label(
+            label='Refresh detected results in the view every N files processed during a scan.'
+        )
+        interval_help.set_xalign(0)
+        interval_help.add_css_class('dim-label')
+        interval_help.set_wrap(True)
+        interval_help.set_hexpand(True)
+        grid.attach(interval_help, 2, 3, 2, 1)
 
         # --- Action buttons ---
         action_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
@@ -432,6 +457,7 @@ class NudityDetectorWindow(
                 'model': self._get_model(),
                 'threshold_percent': self.threshold_spin.get_value(),
                 'last_source_folder': self.folder_entry.get_text().strip(),
+                'progress_update_interval': self._get_progress_interval(),
             }
             with open(config_path, 'w', encoding='utf-8') as f:
                 json.dump(data, f, indent=2)
@@ -449,6 +475,9 @@ class NudityDetectorWindow(
         idx = self.theme_dropdown.get_selected()
         themes = list(constants.SUPPORTED_THEMES)
         return themes[idx] if idx < len(themes) else constants.THEME_SYSTEM
+
+    def _get_progress_interval(self) -> int:
+        return max(1, int(self.progress_interval_spin.get_value()))
 
     # ------------------------------------------------------------------
     # Theme
@@ -481,6 +510,7 @@ class NudityDetectorWindow(
         self.nudenet_radio.set_sensitive(not processing)
         self.deepstack_radio.set_sensitive(not processing)
         self.clear_all_button.set_sensitive(not processing)
+        self.progress_interval_spin.set_sensitive(not processing)
         for button_name in (
             'save_session_button',
             'load_session_button',

--- a/src/gui/scanning.py
+++ b/src/gui/scanning.py
@@ -15,9 +15,11 @@ from ..core import constants
 from ..core.utils import (
     DEFAULT_REPORT_DIR,
     classify_files_in_folder,
+    create_session_state,
     get_detected_results,
     get_report_path,
     handle_results,
+    make_scan_config,
     nudity_report,
     normalize_threshold,
     reset_nudity_report,
@@ -86,6 +88,26 @@ class ScanningMixin:
         self.log_message(f"Starting {self._get_model()} scan at {self.threshold_spin.get_value():.0f}% threshold")
         self.log_message(f'Source folder: {folder_path}')
         self.log_message(f'Report folder: {scan_run_dir}')
+
+        # Create the report folder and write an initial empty session immediately
+        # so the run appears in history before any files are processed.
+        try:
+            os.makedirs(scan_run_dir, exist_ok=True)
+            initial_report_path = get_report_path(scan_run_dir)
+            initial_session = create_session_state(
+                scan_config=make_scan_config(
+                    source_folder=folder_path,
+                    model_name=self._get_model(),
+                    threshold_percent=int(self.threshold_spin.get_value()),
+                    theme_mode=self._get_theme_mode(),
+                ),
+                results=[],
+            )
+            save_nudity_report([], initial_report_path, session_state=initial_session)
+            self.last_report_path = initial_report_path
+            self.refresh_scan_history()
+        except Exception:
+            pass
 
         self.processing_thread = threading.Thread(
             target=self.process_files,
@@ -300,8 +322,42 @@ class ScanningMixin:
         model_name = self._get_model()
         threshold_percent = self.threshold_spin.get_value()
         threshold_value = normalize_threshold(threshold_percent)
+        theme_mode = self._get_theme_mode()
         report_path = get_report_path(scan_run_dir)
         existing_files = set()
+        update_interval = self._get_progress_interval()
+        files_processed = [0]
+        count_lock = threading.Lock()
+
+        def _flush_intermediate():
+            """Save a partial report snapshot and push results to the UI (worker thread)."""
+            try:
+                snapshot = list(nudity_report)
+                intermediate_session = create_session_state(
+                    scan_config=make_scan_config(
+                        source_folder=folder_path,
+                        model_name=model_name,
+                        threshold_percent=threshold_percent,
+                        theme_mode=theme_mode,
+                    ),
+                    results=snapshot,
+                )
+                save_nudity_report(snapshot, report_path, session_state=intermediate_session)
+            except Exception:
+                pass
+            current_results = get_detected_results(nudity_report)
+            GLib.idle_add(self._apply_intermediate_results, list(current_results))
+
+        def _with_progress(fn):
+            """Wrap a classifier to count processed files and flush every N."""
+            def wrapper(file_path):
+                fn(file_path)
+                with count_lock:
+                    files_processed[0] += 1
+                    count = files_processed[0]
+                if count % update_interval == 0:
+                    _flush_intermediate()
+            return wrapper
 
         try:
             if model_name == constants.MODEL_NUDENET:
@@ -312,6 +368,9 @@ class ScanningMixin:
                 classify_image, classify_video = self.create_deepstack_classifiers(
                     existing_files, threshold_value, threshold_percent,
                 )
+
+            classify_image = _with_progress(classify_image)
+            classify_video = _with_progress(classify_video)
 
             classify_files_in_folder(folder_path, classify_image, classify_video)
 
@@ -342,6 +401,17 @@ class ScanningMixin:
         self._pulse_source_id = None
         self.progress_bar.set_fraction(0.0)
         return False
+
+    def _apply_intermediate_results(self, results):
+        """Update the results view with a mid-scan snapshot (called on the main thread)."""
+        self.detected_results = results
+        self.populate_results(results)
+        count = len(results)
+        if self.is_processing:
+            self.summary_label.set_text(
+                f'{count} explicit item(s) detected so far. Scan still running...'
+                if count else 'Scan running... No detections yet.'
+            )
 
     def finish_processing(self):
         self.is_processing = False

--- a/src/gui/scanning.py
+++ b/src/gui/scanning.py
@@ -22,6 +22,7 @@ from ..core.utils import (
     make_scan_config,
     nudity_report,
     normalize_threshold,
+    report_lock,
     reset_nudity_report,
     save_nudity_report,
 )
@@ -106,8 +107,8 @@ class ScanningMixin:
             save_nudity_report([], initial_report_path, session_state=initial_session)
             self.last_report_path = initial_report_path
             self.refresh_scan_history()
-        except Exception:
-            pass
+        except OSError as error:
+            self.log_message(f'Warning: could not create initial report: {error}')
 
         self.processing_thread = threading.Thread(
             target=self.process_files,
@@ -331,8 +332,10 @@ class ScanningMixin:
 
         def _flush_intermediate():
             """Save a partial report snapshot and push results to the UI (worker thread)."""
+            snapshot = []
             try:
-                snapshot = list(nudity_report)
+                with report_lock:
+                    snapshot = list(nudity_report)
                 intermediate_session = create_session_state(
                     scan_config=make_scan_config(
                         source_folder=folder_path,
@@ -345,13 +348,15 @@ class ScanningMixin:
                 save_nudity_report(snapshot, report_path, session_state=intermediate_session)
             except Exception:
                 pass
-            current_results = get_detected_results(nudity_report)
+            current_results = get_detected_results(snapshot)
             GLib.idle_add(self._apply_intermediate_results, list(current_results))
 
         def _with_progress(fn):
             """Wrap a classifier to count processed files and flush every N."""
             def wrapper(file_path):
                 fn(file_path)
+                if not self.is_processing:
+                    return
                 with count_lock:
                     files_processed[0] += 1
                     count = files_processed[0]
@@ -404,14 +409,15 @@ class ScanningMixin:
 
     def _apply_intermediate_results(self, results):
         """Update the results view with a mid-scan snapshot (called on the main thread)."""
+        if not self.is_processing:
+            return
         self.detected_results = results
         self.populate_results(results)
         count = len(results)
-        if self.is_processing:
-            self.summary_label.set_text(
-                f'{count} explicit item(s) detected so far. Scan still running...'
-                if count else 'Scan running... No detections yet.'
-            )
+        self.summary_label.set_text(
+            f'{count} explicit item(s) detected so far. Scan still running...'
+            if count else 'Scan running... No detections yet.'
+        )
 
     def finish_processing(self):
         self.is_processing = False


### PR DESCRIPTION
This pull request introduces a user-configurable scan progress update interval to the application's scanning workflow. Users can now control how frequently the UI and report files are updated with detected results during a scan, improving responsiveness and flexibility for different workloads. The main changes are grouped below:

**User Interface Enhancements:**

* Added a new "Update Every" spin button to the scan settings page, allowing users to set how many files are processed between UI/report refreshes. The control is disabled during active scans. (`src/gui/app.py`, [[1]](diffhunk://#diff-989b26341a1889b35d8fdfb35bccbc855c5191140f47cf34c60ea6956d60e2b7R208-R231) [[2]](diffhunk://#diff-989b26341a1889b35d8fdfb35bccbc855c5191140f47cf34c60ea6956d60e2b7R513)
* The chosen interval is saved to and loaded from the configuration file, ensuring persistence between sessions. (`src/gui/app.py`, [[1]](diffhunk://#diff-989b26341a1889b35d8fdfb35bccbc855c5191140f47cf34c60ea6956d60e2b7R53) [[2]](diffhunk://#diff-989b26341a1889b35d8fdfb35bccbc855c5191140f47cf34c60ea6956d60e2b7R460) [[3]](diffhunk://#diff-989b26341a1889b35d8fdfb35bccbc855c5191140f47cf34c60ea6956d60e2b7R479-R481)

**Core and Scanning Logic:**

* Introduced the constant `SCAN_PROGRESS_UPDATE_INTERVAL` (default 100) to define the default flush interval for UI/report updates. (`src/core/constants.py`, [src/core/constants.pyR187-R191](diffhunk://#diff-4992c45370cc3d34a4d5ade80b891b62eb2f8c3165a38592d1b50e522c97d4a6R187-R191))
* Updated the scanning workflow to flush intermediate results to the UI and report file every N files, where N is user-configurable. This involves wrapping the image/video classification functions to count processed files and trigger intermediate updates. (`src/gui/scanning.py`, [[1]](diffhunk://#diff-6a1e7c994a6c2168fc88df4b79dde6d6098137b4099cb53eac1d0deee27fcabcR325-R360) [[2]](diffhunk://#diff-6a1e7c994a6c2168fc88df4b79dde6d6098137b4099cb53eac1d0deee27fcabcR372-R374)
* Added logic to create an initial empty session/report at the start of a scan, so the scan run appears in history immediately. (`src/gui/scanning.py`, [src/gui/scanning.pyR92-R111](diffhunk://#diff-6a1e7c994a6c2168fc88df4b79dde6d6098137b4099cb53eac1d0deee27fcabcR92-R111))
* Implemented a method to apply intermediate results to the UI mid-scan, updating the results view and summary label accordingly. (`src/gui/scanning.py`, [src/gui/scanning.pyR405-R415](diffhunk://#diff-6a1e7c994a6c2168fc88df4b79dde6d6098137b4099cb53eac1d0deee27fcabcR405-R415))

These changes together provide a more interactive and configurable scanning experience for users.