### PR TITLE
fix: resolve #15 - Refactor FrameExtractor to use lazy/streaming frame extracti

### DIFF
--- a/src/detectors/helloz_nsfw.py
+++ b/src/detectors/helloz_nsfw.py
@@ -86,17 +86,15 @@ def main():
             logging.info('Skipping already scanned file: %s', file_path)
             return
 
-        temp_dir = None
+        extractor = FrameExtractor(
+            frame_rate=constants.VIDEO_FRAME_RATE,
+            temp_prefix=constants.FRAME_TEMP_DIR_PREFIX_CLI_HELLOZ_NSFW,
+        )
         try:
-            extractor = FrameExtractor(
-                frame_rate=constants.VIDEO_FRAME_RATE,
-                temp_prefix=constants.FRAME_TEMP_DIR_PREFIX_CLI_HELLOZ_NSFW,
-            )
-            temp_dir, frame_paths = extractor.extract(file_path)
             frame_scores = []
             max_confidence = 0.0
 
-            for frame_path in frame_paths:
+            for frame_path in extractor.iter_frames(file_path):
                 with open(frame_path, 'rb') as image_file:
                     response = requests.post(constants.HELLOZ_NSFW_URL, files={'file': image_file}, timeout=constants.HELLOZ_NSFW_REQUEST_TIMEOUT)
                 if response.status_code != 200:
@@ -122,8 +120,7 @@ def main():
         except Exception as error:
             logging.error('Error classifying video %s: %s', file_path, error)
         finally:
-            if temp_dir:
-                extractor.cleanup()
+            extractor.cleanup()
 
     logging.debug('User input folder: %s', folder_to_classify)
     reset_nudity_report()

--- a/src/detectors/nudenet.py
+++ b/src/detectors/nudenet.py
@@ -93,17 +93,15 @@ def main():
             logging.info('Skipping already scanned file: %s', file_path)
             return
 
-        temp_dir = None
+        extractor = FrameExtractor(
+            frame_rate=constants.VIDEO_FRAME_RATE,
+            temp_prefix=constants.FRAME_TEMP_DIR_PREFIX_CLI_NUDENET,
+        )
         try:
-            extractor = FrameExtractor(
-                frame_rate=constants.VIDEO_FRAME_RATE,
-                temp_prefix=constants.FRAME_TEMP_DIR_PREFIX_CLI_NUDENET,
-            )
-            temp_dir, frame_paths = extractor.extract(file_path)
             detection_results = []
             max_confidence = 0.0
 
-            for frame_path in frame_paths:
+            for frame_path in extractor.iter_frames(file_path):
                 frame_result = detector.detect(frame_path)
                 simplified_frame = simplify_nudenet_results(frame_result)
                 detection_results.append({'frame': os.path.basename(frame_path), 'detections': simplified_frame})
@@ -123,8 +121,7 @@ def main():
         except Exception as error:
             logging.error('Error classifying video %s: %s', file_path, error)
         finally:
-            if temp_dir:
-                extractor.cleanup()
+            extractor.cleanup()
 
     logging.debug('User input folder: %s', folder_to_classify)
     reset_nudity_report()

--- a/src/gui/scanning.py
+++ b/src/gui/scanning.py
@@ -147,10 +147,6 @@ class ScanningMixin:
         )
         return extractor, extractor.iter_frames(file_path)
 
-    @staticmethod
-    def cleanup_frame_dir(extractor, _frame_paths):
-        extractor.cleanup()
-
     # ------------------------------------------------------------------
     # NudeNet classifiers
     # ------------------------------------------------------------------
@@ -256,7 +252,7 @@ class ScanningMixin:
                     threshold_percent=threshold_percent,
                 )
             finally:
-                self.cleanup_frame_dir(extractor, frame_paths)
+                extractor.cleanup()
 
         return classify_image, classify_video
 
@@ -328,7 +324,7 @@ class ScanningMixin:
                 threshold_percent=threshold_percent,
             )
         finally:
-            self.cleanup_frame_dir(extractor, frame_paths)
+            extractor.cleanup()
 
     def create_helloz_nsfw_classifiers(self, existing_files, threshold_value, threshold_percent):
         import requests

--- a/src/gui/scanning.py
+++ b/src/gui/scanning.py
@@ -1,19 +1,16 @@
 import logging
 import os
-import shutil
 import sys
-import tempfile
 import threading
 from datetime import datetime
 from functools import partial
-
-import cv2
 
 import gi
 gi.require_version('Gtk', '4.0')
 from gi.repository import GLib
 
 from ..core import constants
+from ..processing.media_processor import FrameExtractor
 from ..core.utils import (
     DEFAULT_REPORT_DIR,
     classify_files_in_folder,
@@ -144,27 +141,15 @@ class ScanningMixin:
         return None
 
     def extract_video_frames(self, file_path, temp_prefix):
-        temp_dir = tempfile.mkdtemp(prefix=temp_prefix, dir=self._frame_temp_dir_base())
-        frame_paths = []
-        cap = cv2.VideoCapture(file_path)
-        frame_count = 0
-        video_frame_rate = self._get_video_frame_rate()
-        try:
-            while cap.isOpened() and self.is_processing:
-                ret, frame = cap.read()
-                if not ret:
-                    break
-                if frame_count % video_frame_rate == 0:
-                    frame_path = os.path.join(temp_dir, constants.FRAME_FILE_NAME_PATTERN.format(frame_count))
-                    cv2.imwrite(frame_path, frame)
-                    frame_paths.append(frame_path)
-                frame_count += 1
-        finally:
-            cap.release()
-        return temp_dir, frame_paths
+        extractor = FrameExtractor(
+            frame_rate=self._get_video_frame_rate(),
+            temp_prefix=temp_prefix,
+        )
+        return extractor, extractor.iter_frames(file_path)
 
-    def cleanup_frame_dir(self, temp_dir, _frame_paths):
-        shutil.rmtree(temp_dir, ignore_errors=True)
+    @staticmethod
+    def cleanup_frame_dir(extractor, _frame_paths):
+        extractor.cleanup()
 
     # ------------------------------------------------------------------
     # NudeNet classifiers
@@ -232,7 +217,7 @@ class ScanningMixin:
                 return
             if self._verbose_log:
                 GLib.idle_add(self.log_message, f'Processing video: {os.path.basename(file_path)}')
-            temp_dir, frame_paths = self.extract_video_frames(file_path, constants.FRAME_TEMP_DIR_PREFIX_GUI_NUDENET)
+            extractor, frame_paths = self.extract_video_frames(file_path, constants.FRAME_TEMP_DIR_PREFIX_GUI_NUDENET)
             try:
                 detection_results = []
                 max_confidence = 0.0
@@ -271,7 +256,7 @@ class ScanningMixin:
                     threshold_percent=threshold_percent,
                 )
             finally:
-                self.cleanup_frame_dir(temp_dir, frame_paths)
+                self.cleanup_frame_dir(extractor, frame_paths)
 
         return classify_image, classify_video
 
@@ -318,7 +303,7 @@ class ScanningMixin:
             return
         if self._verbose_log:
             GLib.idle_add(self.log_message, f'Processing video: {os.path.basename(file_path)}')
-        temp_dir, frame_paths = self.extract_video_frames(file_path, constants.FRAME_TEMP_DIR_PREFIX_GUI_HELLOZ_NSFW)
+        extractor, frame_paths = self.extract_video_frames(file_path, constants.FRAME_TEMP_DIR_PREFIX_GUI_HELLOZ_NSFW)
         try:
             frame_scores = []
             max_confidence = 0.0
@@ -343,7 +328,7 @@ class ScanningMixin:
                 threshold_percent=threshold_percent,
             )
         finally:
-            self.cleanup_frame_dir(temp_dir, frame_paths)
+            self.cleanup_frame_dir(extractor, frame_paths)
 
     def create_helloz_nsfw_classifiers(self, existing_files, threshold_value, threshold_percent):
         import requests

--- a/src/processing/media_processor.py
+++ b/src/processing/media_processor.py
@@ -115,7 +115,7 @@ class FrameExtractor:
         if cv2 is None:
             raise RuntimeError('OpenCV (cv2) is required for frame extraction but is not installed')
 
-        # Reset state — mirrors extract() lines 88-89.
+        # Clean up any previous temp directory and reset state for a new extraction run.
         self.cleanup()
         self.temp_dir = tempfile.mkdtemp(prefix=self.temp_prefix)
         self.frame_paths = []

--- a/src/processing/media_processor.py
+++ b/src/processing/media_processor.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import tempfile
 from io import BytesIO
-from typing import Optional, Tuple, List
+from typing import Generator, Optional, Tuple, List
 
 try:
     import cv2
@@ -51,7 +51,12 @@ def is_supported_file(file_path: str) -> bool:
 
 
 class FrameExtractor:
-    """Extracts video frames with configurable sampling rate."""
+    """Extracts video frames with configurable sampling rate.
+
+    Supports both eager extraction via extract() and lazy/streaming
+    extraction via iter_frames(). Use iter_frames() for large videos
+    to enable early-exit and avoid writing unneeded frames to disk.
+    """
 
     def __init__(self, frame_rate: int = constants.VIDEO_FRAME_RATE, temp_prefix: str = ''):
         """Initialize frame extractor.
@@ -71,20 +76,46 @@ class FrameExtractor:
         self.frame_paths: List[str] = []
 
     def extract(self, file_path: str) -> Tuple[str, List[str]]:
-        """Extract frames from video file.
+        """Extract all frames from a video file (eager, backward-compatible shim).
 
-        Args:
-            file_path: Path to video file
+        Delegates to iter_frames(). Prefer iter_frames() for large videos
+        to enable early-exit and avoid writing unneeded frames.
 
         Returns:
             Tuple of (temp_dir, frame_paths)
+        """
+        # Consume the generator fully — iter_frames() resets state internally.
+        for _ in self.iter_frames(file_path):
+            pass
+        return self.temp_dir, self.frame_paths
+
+    # Benchmark note: For a 60-min video at 30fps with VIDEO_FRAME_RATE=10,
+    # early exit at frame N saves writing approximately (10800 - N) JPEG frames to disk.
+    def iter_frames(self, file_path: str) -> Generator[str, None, None]:
+        """Yield one frame path at a time for lazy/streaming processing.
+
+        Writes each sampled frame to a temporary directory on demand and
+        yields its path. The caller can break early to avoid writing
+        unneeded frames.
+
+        The temporary directory is owned by self.temp_dir. Callers MUST
+        call self.cleanup() unconditionally after iteration (even after
+        an early break), because the temp_dir is created before the first
+        yield.
+
+        Args:
+            file_path: Path to the video file.
+
+        Yields:
+            Absolute path to each written frame JPEG.
 
         Raises:
-            RuntimeError: If OpenCV is not available or video cannot be opened
+            RuntimeError: If OpenCV is unavailable or the video cannot be opened.
         """
         if cv2 is None:
             raise RuntimeError('OpenCV (cv2) is required for frame extraction but is not installed')
 
+        # Reset state — mirrors extract() lines 88-89.
         self.temp_dir = tempfile.mkdtemp(prefix=self.temp_prefix)
         self.frame_paths = []
 
@@ -99,17 +130,17 @@ class FrameExtractor:
                 ret, frame = cap.read()
                 if not ret:
                     break
-
                 if frame_count % self.frame_rate == 0:
-                    frame_path = os.path.join(self.temp_dir, constants.FRAME_FILE_NAME_PATTERN.format(frame_count))
+                    frame_path = os.path.join(
+                        self.temp_dir,
+                        constants.FRAME_FILE_NAME_PATTERN.format(frame_count)
+                    )
                     cv2.imwrite(frame_path, frame)
                     self.frame_paths.append(frame_path)
-
+                    yield frame_path
                 frame_count += 1
         finally:
             cap.release()
-
-        return self.temp_dir, self.frame_paths
 
     def cleanup(self) -> None:
         """Clean up temporary frame directory."""

--- a/src/processing/media_processor.py
+++ b/src/processing/media_processor.py
@@ -116,6 +116,7 @@ class FrameExtractor:
             raise RuntimeError('OpenCV (cv2) is required for frame extraction but is not installed')
 
         # Reset state — mirrors extract() lines 88-89.
+        self.cleanup()
         self.temp_dir = tempfile.mkdtemp(prefix=self.temp_prefix)
         self.frame_paths = []
 

--- a/tests/test_frame_extractor_issue15.py
+++ b/tests/test_frame_extractor_issue15.py
@@ -1,0 +1,111 @@
+"""Tests for issue #15 - FrameExtractor lazy/streaming frame extraction."""
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch, call
+
+import numpy as np
+import pytest
+
+# We need cv2 for synthetic video creation
+try:
+    import cv2
+    HAS_CV2 = True
+except ImportError:
+    HAS_CV2 = False
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from src.processing.media_processor import FrameExtractor
+
+
+def create_synthetic_video(path, num_frames=30, width=64, height=64, fps=30):
+    """Write a small synthetic video with num_frames frames."""
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
+    writer = cv2.VideoWriter(path, fourcc, fps, (width, height))
+    for i in range(num_frames):
+        frame = np.full((height, width, 3), i * 8 % 256, dtype=np.uint8)
+        writer.write(frame)
+    writer.release()
+
+
+@pytest.mark.skipif(not HAS_CV2, reason='cv2 not available')
+def test_iter_frames_early_exit_writes_only_n_frames(tmp_path):
+    """Test that breaking early from iter_frames only writes N frames to disk."""
+    video_path = str(tmp_path / 'test_video.mp4')
+    # 30 frames at frame_rate=1 -> 30 sampled frames; we break at 3
+    create_synthetic_video(video_path, num_frames=30)
+
+    extractor = FrameExtractor(frame_rate=1)
+    count = 0
+    for frame_path in extractor.iter_frames(video_path):
+        count += 1
+        if count == 3:
+            break
+
+    # Exactly 3 JPEG files should exist at break point
+    temp_dir = extractor.temp_dir
+    assert temp_dir is not None
+    jpegs = [f for f in os.listdir(temp_dir) if f.endswith('.jpg')]
+    assert len(jpegs) == 3
+
+    extractor.cleanup()
+    assert not os.path.isdir(temp_dir)
+
+
+@pytest.mark.skipif(not HAS_CV2, reason='cv2 not available')
+def test_iter_frames_reuse_does_not_accumulate_stale_paths(tmp_path):
+    """Test that calling iter_frames twice resets state (no stale paths)."""
+    video_path = str(tmp_path / 'test_video.mp4')
+    # frame_rate=10, 30 frames -> 3 sampled frames (frames 0, 10, 20)
+    create_synthetic_video(video_path, num_frames=30)
+
+    extractor = FrameExtractor(frame_rate=10)
+
+    # First pass
+    first_paths = list(extractor.iter_frames(video_path))
+    first_temp_dir = extractor.temp_dir
+
+    # Second pass
+    second_paths = list(extractor.iter_frames(video_path))
+    second_temp_dir = extractor.temp_dir
+
+    assert len(extractor.frame_paths) == 3, f'Expected 3, got {len(extractor.frame_paths)}'
+    assert second_temp_dir != first_temp_dir, 'Expected a new temp_dir on second call'
+
+    extractor.cleanup()
+
+
+@pytest.mark.skipif(not HAS_CV2, reason='cv2 not available')
+def test_extract_shim_still_returns_all_frames(tmp_path):
+    """Test that extract() backward-compatible shim returns all sampled frames."""
+    video_path = str(tmp_path / 'test_video.mp4')
+    create_synthetic_video(video_path, num_frames=30)
+
+    extractor = FrameExtractor(frame_rate=10)
+    result = extractor.extract(video_path)
+
+    assert isinstance(result, tuple), 'extract() must return a tuple'
+    assert len(result) == 2, 'extract() must return (temp_dir, frame_paths)'
+    temp_dir, frame_paths = result
+    assert os.path.isdir(temp_dir)
+    assert len(frame_paths) == 3, f'Expected 3 frames, got {len(frame_paths)}'
+
+    extractor.cleanup()
+
+
+def test_cleanup_called_unconditionally_on_zero_frame_video():
+    """Test that cleanup() is called even when iter_frames() yields nothing."""
+    extractor = FrameExtractor(frame_rate=1)
+    cleanup_mock = MagicMock()
+    extractor.cleanup = cleanup_mock
+
+    # Mock iter_frames to yield nothing
+    with patch.object(extractor, 'iter_frames', return_value=iter([])):
+        # Simulate caller pattern from nudenet.py / helloz_nsfw.py
+        try:
+            for _ in extractor.iter_frames('dummy_path'):
+                pass
+        finally:
+            extractor.cleanup()
+
+    cleanup_mock.assert_called_once()

--- a/tests/test_frame_extractor_issue15.py
+++ b/tests/test_frame_extractor_issue15.py
@@ -71,6 +71,7 @@ def test_iter_frames_reuse_does_not_accumulate_stale_paths(tmp_path):
 
     assert len(extractor.frame_paths) == 3, f'Expected 3, got {len(extractor.frame_paths)}'
     assert second_temp_dir != first_temp_dir, 'Expected a new temp_dir on second call'
+    assert not os.path.isdir(first_temp_dir), 'Expected first temp_dir to be cleaned up on reuse'
 
     extractor.cleanup()
 


### PR DESCRIPTION
## Summary
Resolves #15 — Refactor FrameExtractor to use lazy/streaming frame extraction, avoiding full video decode upfront

**Project:** [Nudity Detector project](#10) — _None_
## Changes
**Tasks:**
- Add `Generator` to the `typing` import on line 13
- Add `iter_frames(self, file_path: str) -> Generator[str, None, None]` method
- Refactor `extract()` (lines 73-112) into a backward-compatible shim that
- Add benchmark comment above `iter_frames()` documenting the I/O saving:
- In `classify_video()` (lines 91-127):
- Replace `temp_dir, frame_paths = extractor.extract(file_path)` (line 102)
- Remove `frame_paths` as a separate list — frames are consumed inline from
- In the `finally` block (line 126):
- In `classify_video()` (lines 84-126):
- Replace `temp_dir, frame_paths = extractor.extract(file_path)` (line 95)
- Remove `frame_paths` as a separate list — same pattern as nudenet.py above.
- Add unit test: `test_iter_frames_early_exit_writes_only_n_frames`
- Add unit test: `test_iter_frames_reuse_does_not_accumulate_stale_paths`
- Add unit test: `test_extract_shim_still_returns_all_frames`
- Add unit test: `test_cleanup_called_unconditionally_on_zero_frame_video`
- Update `extract()` docstring to state it is a shim delegating to iter_frames()
- Update `FrameExtractor` class docstring to mention iter_frames() and the
## Testing
Run the full test suite — all tests must pass.
Closes #15