### PR TITLE
fix: resolve #17 - Replace module-level mutable global `nudity_report` with an 

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,3 @@
+from .scan_session import ScanSession
+
+__all__ = ["ScanSession"]

--- a/src/core/scan_session.py
+++ b/src/core/scan_session.py
@@ -17,9 +17,11 @@ class ScanSession:
         self._results: List[ReportEntry] = list(initial_results or [])
         self._lock = Lock()
 
-    def add_result(self, entry: ReportEntry) -> None:
+    def add_result(self, entry: ReportEntry) -> int:
+        """Append *entry* and return the new total count, both under the lock."""
         with self._lock:
             self._results.append(entry)
+            return len(self._results)
 
     def get_results(self) -> List[ReportEntry]:
         with self._lock:

--- a/src/core/scan_session.py
+++ b/src/core/scan_session.py
@@ -1,0 +1,30 @@
+"""Encapsulated scan-session context object."""
+from threading import Lock
+from typing import List, Optional
+from .models import ReportEntry
+
+
+class ScanSession:
+    """Encapsulates the mutable state of a single scan run.
+
+    Each scan run creates one ScanSession instance. Detectors append results
+    via add_result(); the GUI and CLI read them via get_results(). The internal
+    Lock makes concurrent appends from worker threads safe without callers
+    managing any lock themselves.
+    """
+
+    def __init__(self, initial_results: Optional[List] = None) -> None:
+        self._results: List[ReportEntry] = list(initial_results or [])
+        self._lock = Lock()
+
+    def add_result(self, entry: ReportEntry) -> None:
+        with self._lock:
+            self._results.append(entry)
+
+    def get_results(self) -> List[ReportEntry]:
+        with self._lock:
+            return list(self._results)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._results.clear()

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -463,11 +463,11 @@ def handle_results(
         constants.RESULT_FIELD_DATE: datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
     }
     entry = ReportEntry.from_dict(entry_data)
-    session.add_result(entry)
+    count = session.add_result(entry)
 
-    # Periodically save report
-    all_results = session.get_results()
-    if len(all_results) % 500 == 0:
-        ReportManager.save_entries(all_results, get_report_path(report_dir))
+    # Periodically save report — use the count returned by add_result so the
+    # % 500 boundary check is consistent with the atomic append.
+    if count % 500 == 0:
+        ReportManager.save_entries(session.get_results(), get_report_path(report_dir))
 
     return entry_data

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -7,7 +7,6 @@ This module provides:
 - Integration layer between detection models and storage
 
 Thread Safety:
-- nudity_report list is protected by report_lock
 - Worker threads are non-daemon to ensure proper cleanup
 - All thread operations have explicit join() with timeout
 """
@@ -19,7 +18,7 @@ import subprocess
 import sys
 from datetime import datetime
 from queue import Queue
-from threading import Lock, Thread
+from threading import Thread
 from typing import Optional, Tuple
 
 try:
@@ -29,15 +28,9 @@ except ImportError:
 
 from . import constants
 from .models import ReportEntry, SessionState, ScanConfig
+from .scan_session import ScanSession
 from ..processing.media_processor import detect_media_type, is_supported_file, ThumbnailGenerator
 from ..reporting.report_manager import ReportManager
-
-
-# ============================================================================
-# Global State Management
-# ============================================================================
-nudity_report = []
-report_lock = Lock()
 
 
 # ============================================================================
@@ -88,23 +81,9 @@ def create_session_state(scan_config=None, results=None) -> dict:
     return state.to_dict()
 
 
-def reset_nudity_report() -> None:
-    """Clear the global nudity report list."""
-    with report_lock:
-        nudity_report.clear()
-
-
-def replace_nudity_report(entries: list) -> None:
-    """Replace nudity report contents."""
-    with report_lock:
-        nudity_report.clear()
-        nudity_report.extend(entries)
-
-
-def get_detected_results(report_data=None) -> list:
+def get_detected_results(report_data: list) -> list:
     """Get results where nudity was detected."""
-    data = report_data if report_data is not None else nudity_report
-    return [entry for entry in data if (entry.get('nudity_detected') if isinstance(entry, dict) else entry.nudity_detected)]
+    return [entry for entry in report_data if (entry.get('nudity_detected') if isinstance(entry, dict) else entry.nudity_detected)]
 
 
 # ============================================================================
@@ -438,6 +417,7 @@ def handle_results(
     file_path: str,
     nudity_detected: bool,
     raw_result,
+    session: ScanSession,
     confidence_score: float = 0.0,
     media_type: Optional[str] = None,
     model_name: str = '',
@@ -450,6 +430,7 @@ def handle_results(
         file_path: Original file path
         nudity_detected: Whether nudity was detected
         raw_result: Raw detection result
+        session: ScanSession to append the result to
         confidence_score: Confidence score (0-1)
         media_type: Media type (auto-detected if None)
         model_name: Detection model name
@@ -469,24 +450,24 @@ def handle_results(
     if nudity_detected:
         os.makedirs(report_dir, exist_ok=True)
 
-    # Create and cache entry
-    with report_lock:
-        entry_data = {
-            constants.RESULT_FIELD_FILE: file_path,
-            constants.RESULT_FIELD_MEDIA_TYPE: media_type or detect_media_type(file_path),
-            constants.RESULT_FIELD_MODEL: model_name,
-            constants.RESULT_FIELD_THRESHOLD: threshold_to_percent(threshold_percent),
-            constants.RESULT_FIELD_CONFIDENCE: round(max(0.0, min(float(confidence_score), 1.0)) * 100, 2),
-            constants.RESULT_FIELD_NUDITY: bool(nudity_detected),
-            constants.RESULT_FIELD_CLASSES: json.dumps(raw_result, ensure_ascii=False) if not isinstance(raw_result, str) else raw_result,
-            constants.RESULT_FIELD_THUMBNAIL: thumbnail,
-            constants.RESULT_FIELD_DATE: datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-        }
-        nudity_report.append(entry_data)
+    # Create entry
+    entry_data = {
+        constants.RESULT_FIELD_FILE: file_path,
+        constants.RESULT_FIELD_MEDIA_TYPE: media_type or detect_media_type(file_path),
+        constants.RESULT_FIELD_MODEL: model_name,
+        constants.RESULT_FIELD_THRESHOLD: threshold_to_percent(threshold_percent),
+        constants.RESULT_FIELD_CONFIDENCE: round(max(0.0, min(float(confidence_score), 1.0)) * 100, 2),
+        constants.RESULT_FIELD_NUDITY: bool(nudity_detected),
+        constants.RESULT_FIELD_CLASSES: json.dumps(raw_result, ensure_ascii=False) if not isinstance(raw_result, str) else raw_result,
+        constants.RESULT_FIELD_THUMBNAIL: thumbnail,
+        constants.RESULT_FIELD_DATE: datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+    }
+    entry = ReportEntry.from_dict(entry_data)
+    session.add_result(entry)
 
-        # Periodically save report
-        if len(nudity_report) % 500 == 0:
-            entries = [ReportEntry.from_dict(e) for e in nudity_report]
-            ReportManager.save_entries(entries, get_report_path(report_dir))
+    # Periodically save report
+    all_results = session.get_results()
+    if len(all_results) % 500 == 0:
+        ReportManager.save_entries(all_results, get_report_path(report_dir))
 
-        return entry_data
+    return entry_data

--- a/src/detectors/helloz_nsfw.py
+++ b/src/detectors/helloz_nsfw.py
@@ -4,6 +4,7 @@ import os
 import requests
 
 from ..core import constants
+from ..core.scan_session import ScanSession
 from ..core.utils import (
     classify_files_in_folder,
     create_session_state,
@@ -12,9 +13,7 @@ from ..core.utils import (
     handle_results,
     load_existing_report,
     make_scan_config,
-    nudity_report,
     normalize_threshold,
-    reset_nudity_report,
     save_nudity_report,
 )
 from ..processing.media_processor import FrameExtractor
@@ -43,6 +42,7 @@ def extract_frames(file_path, frame_rate=constants.VIDEO_FRAME_RATE):
 def main():
     report_path = get_report_path()
     existing_files = load_existing_report(report_path)
+    session = ScanSession()
 
     folder_to_classify = input('Enter the path to the folder: ').strip()
     threshold_percent = prompt_threshold_percent()
@@ -73,6 +73,7 @@ def main():
                 file_path,
                 confidence_score >= threshold_value,
                 result,
+                session=session,
                 confidence_score=confidence_score,
                 media_type=constants.MEDIA_TYPE_IMAGE,
                 model_name=constants.MODEL_HELLOZ_NSFW,
@@ -112,6 +113,7 @@ def main():
                 file_path,
                 max_confidence >= threshold_value,
                 frame_scores,
+                session=session,
                 confidence_score=max_confidence,
                 media_type=constants.MEDIA_TYPE_VIDEO,
                 model_name=constants.MODEL_HELLOZ_NSFW,
@@ -123,11 +125,11 @@ def main():
             extractor.cleanup()
 
     logging.debug('User input folder: %s', folder_to_classify)
-    reset_nudity_report()
     classify_files_in_folder(folder_to_classify, classify_image, classify_video)
 
-    session_state = create_session_state(scan_config=scan_config, results=get_detected_results(nudity_report))
-    save_nudity_report(nudity_report, report_path, session_state=session_state)
+    all_results = session.get_results()
+    session_state = create_session_state(scan_config=scan_config, results=get_detected_results(all_results))
+    save_nudity_report(all_results, report_path, session_state=session_state)
     logging.info('Report saved to %s', report_path)
 
 

--- a/src/detectors/nudenet.py
+++ b/src/detectors/nudenet.py
@@ -5,6 +5,7 @@ import os
 from nudenet import NudeDetector
 
 from ..core import constants
+from ..core.scan_session import ScanSession
 from ..core.utils import (
     classify_files_in_folder,
     create_session_state,
@@ -13,9 +14,7 @@ from ..core.utils import (
     handle_results,
     load_existing_report,
     make_scan_config,
-    nudity_report,
     normalize_threshold,
-    reset_nudity_report,
     save_nudity_report,
 )
 from ..processing.media_processor import FrameExtractor
@@ -55,6 +54,7 @@ def main():
     report_path = get_report_path()
     existing_files = load_existing_report(report_path)
     detector = NudeDetector()
+    session = ScanSession()
 
     folder_to_classify = input('Enter the path to the folder: ').strip()
     threshold_percent = prompt_threshold_percent()
@@ -80,6 +80,7 @@ def main():
                 file_path,
                 nudity_detected,
                 simplified_results,
+                session=session,
                 confidence_score=confidence_score,
                 media_type=constants.MEDIA_TYPE_IMAGE,
                 model_name=constants.MODEL_NUDENET,
@@ -113,6 +114,7 @@ def main():
                 file_path,
                 max_confidence >= threshold_value,
                 detection_results,
+                session=session,
                 confidence_score=max_confidence,
                 media_type=constants.MEDIA_TYPE_VIDEO,
                 model_name=constants.MODEL_NUDENET,
@@ -124,11 +126,11 @@ def main():
             extractor.cleanup()
 
     logging.debug('User input folder: %s', folder_to_classify)
-    reset_nudity_report()
     classify_files_in_folder(folder_to_classify, classify_image, classify_video)
 
-    session_state = create_session_state(scan_config=scan_config, results=get_detected_results(nudity_report))
-    save_nudity_report(nudity_report, report_path, session_state=session_state)
+    all_results = session.get_results()
+    session_state = create_session_state(scan_config=scan_config, results=get_detected_results(all_results))
+    save_nudity_report(all_results, report_path, session_state=session_state)
     logging.info('Report saved to %s', report_path)
 
 

--- a/src/gui/results.py
+++ b/src/gui/results.py
@@ -7,10 +7,8 @@ from gi.repository import Gio, Gtk
 from ..core import constants
 from ..core.utils import (
     delete_file_safely,
-    nudity_report,
     open_file,
     open_file_location,
-    replace_nudity_report,
     save_nudity_report,
 )
 from .result_item import ResultItem
@@ -159,8 +157,13 @@ class ResultsMixin:
             self._show_error('Delete failed', message)
             return
         del self.detected_results[index]
-        remaining = [item for item in nudity_report if item.get('file') != entry.get('file')]
-        replace_nudity_report(remaining)
-        save_nudity_report(nudity_report, self.last_report_path, session_state=self.build_session_state())
+        if hasattr(self, '_scan_session') and self._scan_session:
+            remaining = [e for e in self._scan_session.get_results() if e.file != entry.get('file')]
+            self._scan_session.reset()
+            for e in remaining:
+                self._scan_session.add_result(e)
+            save_nudity_report(remaining, self.last_report_path, session_state=self.build_session_state())
+        else:
+            save_nudity_report(self.detected_results, self.last_report_path, session_state=self.build_session_state())
         self.populate_results(self.detected_results)
         self.log_message(f"Deleted {entry.get('file', '')}. {message}", 'success')

--- a/src/gui/scanning.py
+++ b/src/gui/scanning.py
@@ -21,12 +21,10 @@ from ..core.utils import (
     get_report_path,
     handle_results,
     make_scan_config,
-    nudity_report,
     normalize_threshold,
-    report_lock,
-    reset_nudity_report,
     save_nudity_report,
 )
+from ..core.scan_session import ScanSession
 
 
 class ScanningMixin:
@@ -78,7 +76,7 @@ class ScanningMixin:
         self.is_processing = True
         self.detected_results = []
         self.populate_results([])
-        reset_nudity_report()
+        self._scan_session = ScanSession()
         self.log_buffer.set_text('')
         self.set_controls_for_processing(True)
         self._start_progress_pulse()
@@ -151,7 +149,7 @@ class ScanningMixin:
     # NudeNet classifiers
     # ------------------------------------------------------------------
 
-    def create_nudenet_classifiers(self, existing_files, threshold_value, threshold_percent):
+    def create_nudenet_classifiers(self, existing_files, threshold_value, threshold_percent, session):
         from nudenet import NudeDetector
 
         detector = NudeDetector()
@@ -202,6 +200,7 @@ class ScanningMixin:
                 file_path,
                 confidence_score >= threshold_value,
                 simplify_results(detection_result),
+                session=session,
                 confidence_score=confidence_score,
                 media_type='image',
                 model_name='nudenet',
@@ -246,6 +245,7 @@ class ScanningMixin:
                     file_path,
                     max_confidence >= threshold_value,
                     detection_results,
+                    session=session,
                     confidence_score=max_confidence,
                     media_type='video',
                     model_name='nudenet',
@@ -274,7 +274,7 @@ class ScanningMixin:
         confidence_score = float(result.get('data', {}).get('nsfw', 0.0))
         return result, confidence_score
 
-    def run_helloz_nsfw_image(self, file_path, existing_files, threshold_value, threshold_percent, requests_module, helloz_nsfw_url, request_timeout):
+    def run_helloz_nsfw_image(self, file_path, existing_files, threshold_value, threshold_percent, requests_module, helloz_nsfw_url, request_timeout, session):
         if not self.is_processing or file_path in existing_files:
             return
         if self._verbose_log:
@@ -288,13 +288,14 @@ class ScanningMixin:
             file_path,
             confidence_score >= threshold_value,
             result,
+            session=session,
             confidence_score=confidence_score,
             media_type='image',
             model_name='helloz_nsfw',
             threshold_percent=threshold_percent,
         )
 
-    def run_helloz_nsfw_video(self, file_path, existing_files, threshold_value, threshold_percent, requests_module, helloz_nsfw_url, request_timeout):
+    def run_helloz_nsfw_video(self, file_path, existing_files, threshold_value, threshold_percent, requests_module, helloz_nsfw_url, request_timeout, session):
         if not self.is_processing or file_path in existing_files:
             return
         if self._verbose_log:
@@ -318,6 +319,7 @@ class ScanningMixin:
                 file_path,
                 max_confidence >= threshold_value,
                 frame_scores,
+                session=session,
                 confidence_score=max_confidence,
                 media_type='video',
                 model_name='helloz_nsfw',
@@ -326,7 +328,7 @@ class ScanningMixin:
         finally:
             extractor.cleanup()
 
-    def create_helloz_nsfw_classifiers(self, existing_files, threshold_value, threshold_percent):
+    def create_helloz_nsfw_classifiers(self, existing_files, threshold_value, threshold_percent, session):
         import requests
 
         helloz_nsfw_url = self._get_helloz_nsfw_url()
@@ -340,6 +342,7 @@ class ScanningMixin:
                 requests_module=requests,
                 helloz_nsfw_url=helloz_nsfw_url,
                 request_timeout=request_timeout,
+                session=session,
             ),
             partial(
                 self.run_helloz_nsfw_video,
@@ -349,6 +352,7 @@ class ScanningMixin:
                 requests_module=requests,
                 helloz_nsfw_url=helloz_nsfw_url,
                 request_timeout=request_timeout,
+                session=session,
             ),
         )
 
@@ -409,8 +413,7 @@ class ScanningMixin:
             """Queue a partial report snapshot for async save, then push new results to UI."""
             snapshot = []
             try:
-                with report_lock:
-                    snapshot = list(nudity_report)
+                snapshot = self._scan_session.get_results()
                 intermediate_session = create_session_state(
                     scan_config=make_scan_config(
                         source_folder=folder_path,
@@ -467,11 +470,11 @@ class ScanningMixin:
         try:
             if model_name == constants.MODEL_NUDENET:
                 classify_image, classify_video = self.create_nudenet_classifiers(
-                    existing_files, threshold_value, threshold_percent,
+                    existing_files, threshold_value, threshold_percent, self._scan_session,
                 )
             else:
                 classify_image, classify_video = self.create_helloz_nsfw_classifiers(
-                    existing_files, threshold_value, threshold_percent,
+                    existing_files, threshold_value, threshold_percent, self._scan_session,
                 )
 
             classify_image = _with_progress(classify_image)
@@ -487,12 +490,13 @@ class ScanningMixin:
 
             processed = files_processed[0]
             skipped = total_files - processed
-            self.detected_results = get_detected_results(nudity_report)
+            all_results = self._scan_session.get_results()
+            self.detected_results = get_detected_results(all_results)
             self.last_report_path = report_path
             session_state = self.build_session_state()
 
             # Write the final definitive report (save thread already drained via finally).
-            save_nudity_report(nudity_report, report_path, session_state=session_state)
+            save_nudity_report(all_results, report_path, session_state=session_state)
             elapsed = datetime.now() - scan_start_time
             total_seconds = int(elapsed.total_seconds())
             minutes, seconds = divmod(total_seconds, 60)

--- a/src/gui/scanning.py
+++ b/src/gui/scanning.py
@@ -370,6 +370,9 @@ class ScanningMixin:
         update_interval = self._get_progress_interval()
         files_processed = [0]
         count_lock = threading.Lock()
+        # Capture the session reference once so that a history-tab reload that
+        # replaces self._scan_session cannot affect the in-flight scan.
+        scan_session = self._scan_session
 
         # ------------------------------------------------------------------
         # Step 1 — Count supported files before starting workers.
@@ -413,7 +416,7 @@ class ScanningMixin:
             """Queue a partial report snapshot for async save, then push new results to UI."""
             snapshot = []
             try:
-                snapshot = self._scan_session.get_results()
+                snapshot = scan_session.get_results()
                 intermediate_session = create_session_state(
                     scan_config=make_scan_config(
                         source_folder=folder_path,
@@ -470,11 +473,11 @@ class ScanningMixin:
         try:
             if model_name == constants.MODEL_NUDENET:
                 classify_image, classify_video = self.create_nudenet_classifiers(
-                    existing_files, threshold_value, threshold_percent, self._scan_session,
+                    existing_files, threshold_value, threshold_percent, scan_session,
                 )
             else:
                 classify_image, classify_video = self.create_helloz_nsfw_classifiers(
-                    existing_files, threshold_value, threshold_percent, self._scan_session,
+                    existing_files, threshold_value, threshold_percent, scan_session,
                 )
 
             classify_image = _with_progress(classify_image)
@@ -490,7 +493,7 @@ class ScanningMixin:
 
             processed = files_processed[0]
             skipped = total_files - processed
-            all_results = self._scan_session.get_results()
+            all_results = scan_session.get_results()
             self.detected_results = get_detected_results(all_results)
             self.last_report_path = report_path
             session_state = self.build_session_state()

--- a/src/gui/session.py
+++ b/src/gui/session.py
@@ -15,10 +15,10 @@ from ..core.utils import (
     load_report_entries,
     load_scan_session,
     make_scan_config,
-    nudity_report,
-    replace_nudity_report,
     save_nudity_report,
 )
+from ..core.scan_session import ScanSession
+from ..core.models import ReportEntry
 
 
 class SessionMixin:
@@ -111,7 +111,8 @@ class SessionMixin:
                 if not report_path.endswith(constants.XLSX_EXTENSION):
                     report_path += constants.XLSX_EXTENSION
                 self.last_report_path = report_path
-                save_nudity_report(nudity_report, report_path, session_state=self.build_session_state())
+                results = self._scan_session.get_results() if hasattr(self, '_scan_session') and self._scan_session else []
+                save_nudity_report(results, report_path, session_state=self.build_session_state())
                 self.open_report_button.set_sensitive(True)
                 self.log_message(f'Saved session report to {report_path}', 'success')
         except GLib.Error:
@@ -169,7 +170,10 @@ class SessionMixin:
         self.threshold_spin.set_value(float(scan_config.get('threshold_percent', 60)))
 
         self.detected_results = detected_results
-        replace_nudity_report(report_entries or detected_results)
+        self._scan_session = ScanSession(initial_results=[
+            entry if not isinstance(entry, dict) else ReportEntry.from_dict(entry)
+            for entry in (report_entries or detected_results)
+        ])
         self.populate_results(self.detected_results)
         self.last_report_path = report_path
         self.open_report_button.set_sensitive(os.path.exists(report_path))

--- a/tests/core/test_scan_session.py
+++ b/tests/core/test_scan_session.py
@@ -32,7 +32,8 @@ def test_empty_construction():
 def test_add_result():
     session = ScanSession()
     entry = _make_entry("b.jpg")
-    session.add_result(entry)
+    count = session.add_result(entry)
+    assert count == 1
     results = session.get_results()
     assert len(results) == 1
     assert results[0].file == "b.jpg"

--- a/tests/core/test_scan_session.py
+++ b/tests/core/test_scan_session.py
@@ -78,3 +78,47 @@ def test_concurrent_append():
         t.join()
 
     assert len(session.get_results()) == N_THREADS * APPENDS_PER_THREAD
+
+
+# ---------------------------------------------------------------------------
+# session-reload path (mirrors src/gui/session.py load_session_from_path)
+# ---------------------------------------------------------------------------
+
+def test_session_reload_creates_scan_session_with_loaded_entries():
+    entries = [_make_entry("x.jpg"), _make_entry("y.jpg")]
+    session = ScanSession(initial_results=entries)
+    assert len(session.get_results()) == 2
+    assert {e.file for e in session.get_results()} == {"x.jpg", "y.jpg"}
+
+
+def test_session_reload_replaces_previous_session():
+    session = ScanSession(initial_results=[_make_entry("old.jpg")])
+    session = ScanSession(initial_results=[_make_entry("new1.jpg"), _make_entry("new2.jpg")])
+    results = session.get_results()
+    assert len(results) == 2
+    assert all(e.file in {"new1.jpg", "new2.jpg"} for e in results)
+
+
+# ---------------------------------------------------------------------------
+# result-deletion path (mirrors src/gui/results.py _do_delete)
+# ---------------------------------------------------------------------------
+
+def test_result_deletion_removes_entry_from_session():
+    entries = [_make_entry("a.jpg"), _make_entry("b.jpg"), _make_entry("c.jpg")]
+    session = ScanSession(initial_results=entries)
+    target_file = "b.jpg"
+    remaining = [e for e in session.get_results() if e.file != target_file]
+    session.reset()
+    for e in remaining:
+        session.add_result(e)
+    results = session.get_results()
+    assert len(results) == 2
+    assert all(e.file != target_file for e in results)
+
+
+def test_result_deletion_no_global_side_effects():
+    s1 = ScanSession(initial_results=[_make_entry("shared.jpg")])
+    s2 = ScanSession(initial_results=[_make_entry("shared.jpg")])
+    s1.reset()
+    assert len(s1.get_results()) == 0
+    assert len(s2.get_results()) == 1

--- a/tests/core/test_scan_session.py
+++ b/tests/core/test_scan_session.py
@@ -1,0 +1,80 @@
+"""Tests for src/core/scan_session.py — issue #17"""
+import sys
+import threading
+import pytest
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("nudenet", MagicMock())
+
+from src.core.scan_session import ScanSession
+
+
+def _make_entry(file="a.jpg", nudity_detected=True):
+    from src.core.models import ReportEntry
+    return ReportEntry(
+        file=file,
+        media_type="image",
+        model_name="nudenet",
+        threshold_percent=60.0,
+        confidence_percent=80.0,
+        nudity_detected=nudity_detected,
+        detected_classes="[]",
+        thumbnail="",
+        date_classified="2024-01-01 00:00:00",
+    )
+
+
+def test_empty_construction():
+    session = ScanSession()
+    assert session.get_results() == []
+
+
+def test_add_result():
+    session = ScanSession()
+    entry = _make_entry("b.jpg")
+    session.add_result(entry)
+    results = session.get_results()
+    assert len(results) == 1
+    assert results[0].file == "b.jpg"
+
+
+def test_get_results_returns_copy():
+    session = ScanSession()
+    entry = _make_entry("c.jpg")
+    session.add_result(entry)
+    r1 = session.get_results()
+    r1.append(_make_entry("extra.jpg"))
+    r2 = session.get_results()
+    assert len(r2) == 1  # mutation of r1 did not affect internal state
+
+
+def test_reset():
+    session = ScanSession()
+    session.add_result(_make_entry("d.jpg"))
+    assert len(session.get_results()) == 1
+    session.reset()
+    assert session.get_results() == []
+
+
+def test_initial_results_constructor_arg():
+    entries = [_make_entry("e.jpg"), _make_entry("f.jpg")]
+    session = ScanSession(initial_results=entries)
+    assert len(session.get_results()) == 2
+
+
+def test_concurrent_append():
+    N_THREADS = 20
+    APPENDS_PER_THREAD = 50
+    session = ScanSession()
+
+    def worker():
+        for _ in range(APPENDS_PER_THREAD):
+            session.add_result(_make_entry("t.jpg"))
+
+    threads = [threading.Thread(target=worker) for _ in range(N_THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(session.get_results()) == N_THREADS * APPENDS_PER_THREAD

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -11,8 +11,6 @@ from src.core.utils import (
     threshold_to_percent,
     make_scan_config,
     get_detected_results,
-    reset_nudity_report,
-    nudity_report,
 )
 
 
@@ -59,8 +57,19 @@ def test_get_detected_results_filters_by_nudity_detected():
     assert all(r["nudity_detected"] for r in results)
 
 
-def test_reset_nudity_report_clears_list():
-    nudity_report.append({"nudity_detected": True, "file": "x.jpg"})
-    assert len(nudity_report) > 0
-    reset_nudity_report()
-    assert nudity_report == []
+def test_handle_results_uses_session(tmp_path):
+    """handle_results appends entry to the provided ScanSession."""
+    from src.core.scan_session import ScanSession
+    from src.core.utils import handle_results
+
+    session = ScanSession()
+    entry = handle_results(
+        file_path=str(tmp_path / "test.jpg"),
+        nudity_detected=False,
+        raw_result=[],
+        session=session,
+        report_dir=str(tmp_path),
+    )
+    results = session.get_results()
+    assert len(results) == 1
+    assert results[0].file == str(tmp_path / "test.jpg")


### PR DESCRIPTION
## Summary
Resolves #17 — Replace module-level mutable global `nudity_report` with an encapsulated scan-session context object

**Project:** [Nudity Detector project](#10) — _Backlog_
## Changes
- Module-level mutable `nudity_report` list and `report_lock`
- `reset_nudity_report()` is a temporal-coupling smell
- `handle_results` appends to the global inside a `report_lock` section
- `get_detected_results` falls back to the global when called without arguments
- `replace_nudity_report` mutates the global in-place
- CLI detectors (`nudenet.py`, `helloz_nsfw.py`) import and use the global
- GUI `scanning.py` imports and directly references the global list
- New `ScanSession` class to be created

**Tasks:**
- Create `src/core/scan_session.py` with the `ScanSession` class (file: `src/core/scan_session.py`)
- Add `__init__` accepting optional `initial_results` list (file: `src/core/scan_session.py`)
- Implement `add_result(entry: ReportEntry)` with internal `Lock` (file: `src/core/scan_session.py`)
- Implement `get_results() -> List[ReportEntry]` returning a copy under lock (file: `src/core/scan_session.py`)
- Implement `reset()` clearing the list under lock (file: `src/core/scan_session.py`)
- Export `ScanSession` from `src/core/__init__.py` (file: `src/core/__init__.py`)
- Remove `nudity_report = []` and `report_lock = Lock()` from module scope (file: `src/core/utils.py` lines 39–40)
- Remove `reset_nudity_report()` function (file: `src/core/utils.py` lines 91–94)
- Remove `replace_nudity_report()` function (file: `src/core/utils.py` lines 97–101)
- Add `session: ScanSession` parameter to `handle_results()` and call `session.add_result(entry)` instead of appending to the global (file: `src/core/utils.py` lines 437–489)
- Remove the `with report_lock:` block from `handle_results()` — locking is now internal to `ScanSession` (file: `src/core/utils.py`)
- Remove the `report_data=None` fallback in `get_detected_results()` — require explicit list argument (file: `src/core/utils.py` lines 104–107)
- Update the module docstring to remove references to `nudity_report` and `report_lock` (file: `src/core/utils.py` lines 1–13)
- Remove imports of `nudity_report`, `report_lock`, `reset_nudity_report` from `src/detectors/nudenet.py` (lines 16–19)
- Create a `ScanSession` instance at the top of the CLI `main()` in `nudenet.py` and pass it to classifiers (file: `src/detectors/nudenet.py`)
- Update `classify_image` / `classify_video` closures in `nudenet.py` to accept and forward `session` to `handle_results` (file: `src/detectors/nudenet.py`)
- Replace `reset_nudity_report()` + `nudity_report` references in `nudenet.py` with session instance calls (file: `src/detectors/nudenet.py` lines 126–130)
- Remove imports of `nudity_report`, `report_lock`, `reset_nudity_report` from `src/detectors/helloz_nsfw.py` (lines 16–19)
- Create a `ScanSession` instance at the top of the CLI `main()` in `helloz_nsfw.py` and pass it to classifiers (file: `src/detectors/helloz_nsfw.py`)
- Update `classify_image` / `classify_video` closures in `helloz_nsfw.py` to accept and forward `session` to `handle_results` (file: `src/detectors/helloz_nsfw.py`)
## Testing
Run the full test suite — all tests must pass.
Closes #17