### PR TITLE
fix: resolve #54 - BUG: Detect media type via magic bytes instead of relying so

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,20 @@ Two detector backends are available:
 
    > **Note:** If you see `ModuleNotFoundError: No module named 'gi'` when running the GUI, this step was not completed. Step 4 must be done first.
 
-6. **Install requirements**:
+7. **Install the `libmagic` system library** (required for magic-byte media type detection):
+
+   The `python-magic` dependency wraps the system `libmagic` shared library, which is used to
+   verify a file's real content type before trusting its extension.
+
+   On Ubuntu/Debian:
+
+   ```bash
+   sudo apt-get install libmagic1
+   ```
+
+   > **Note:** `libmagic1` is already present on most Linux systems (it backs the `file` command).
+
+7. **Install requirements**:
 
   Two dependency files are provided:
 

--- a/requirements.in
+++ b/requirements.in
@@ -8,3 +8,4 @@ opencv-python>=4.13.0.92,<5
 requests>=2.34.2,<3
 Send2Trash>=2.1.0,<3
 darkdetect>=0.8.0,<1
+python-magic>=0.4.27,<1

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,8 @@ protobuf==7.35.0
     #   onnxruntime-gpu
 pydload==1.0.9
     # via vnudenet
+python-magic==0.4.27
+    # via -r requirements.in
 python-utils==3.9.1
     # via progressbar2
 requests==2.34.2

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -12,6 +12,19 @@ IMAGE_EXTENSIONS = frozenset({'.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', 
 VIDEO_EXTENSIONS = frozenset({'.mp4', '.avi', '.mkv', '.mov', '.vob', '.wmv', '.flv', '.3gp', '.webm'})
 SUPPORTED_EXTENSIONS = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
 
+MIME_IMAGE_TYPES = frozenset({
+    'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/tiff', 'image/bmp',
+})
+# NOTE: 'application/octet-stream' is deliberately NOT included here. libmagic reports
+# that generic MIME type as a fallback for a huge range of unrecognized/malformed
+# binary content, so admitting it would let any file renamed to a trusted video
+# extension (e.g. payload.mp4) sail through the extension+MIME cross-check unchanged,
+# defeating the purpose of the magic-byte verification.
+MIME_VIDEO_TYPES = frozenset({
+    'video/mp4', 'video/x-msvideo', 'video/x-matroska', 'video/quicktime',
+    'video/x-ms-wmv', 'video/x-flv', 'video/3gpp', 'video/webm',
+})
+
 MEDIA_TYPE_IMAGE = 'image'
 MEDIA_TYPE_VIDEO = 'video'
 MEDIA_TYPE_UNKNOWN = 'unknown'

--- a/src/processing/media_processor.py
+++ b/src/processing/media_processor.py
@@ -12,6 +12,8 @@ import tempfile
 from io import BytesIO
 from typing import Generator, List, Optional, Tuple
 
+import magic
+
 try:
     import cv2
 except ImportError:
@@ -26,7 +28,13 @@ from ..core import constants
 
 
 def detect_media_type(file_path: str) -> str:
-    """Detect media type from file extension.
+    """Detect media type via extension and magic-byte MIME verification.
+
+    The extension is used as a cheap first-pass filter; the file's real
+    content is then inspected via libmagic and cross-checked against a
+    narrowly-scoped MIME allowlist before the media type is trusted. This
+    prevents a payload crafted to exploit a parser CVE from being classified
+    as image/video purely because of a spoofed extension.
 
     Args:
         file_path: Path to media file
@@ -37,9 +45,18 @@ def detect_media_type(file_path: str) -> str:
     _, ext = os.path.splitext(file_path)
     ext = ext.lower()
 
-    if ext in constants.IMAGE_EXTENSIONS:
+    if ext not in constants.SUPPORTED_EXTENSIONS:
+        return constants.MEDIA_TYPE_UNKNOWN
+
+    try:
+        mime = magic.from_file(file_path, mime=True)
+    except (OSError, magic.MagicException) as e:
+        logging.warning('Could not determine MIME type for %s: %s', file_path, e)
+        return constants.MEDIA_TYPE_UNKNOWN
+
+    if ext in constants.IMAGE_EXTENSIONS and mime in constants.MIME_IMAGE_TYPES:
         return constants.MEDIA_TYPE_IMAGE
-    if ext in constants.VIDEO_EXTENSIONS:
+    if ext in constants.VIDEO_EXTENSIONS and mime in constants.MIME_VIDEO_TYPES:
         return constants.MEDIA_TYPE_VIDEO
 
     return constants.MEDIA_TYPE_UNKNOWN

--- a/tests/core/test_utils_extended.py
+++ b/tests/core/test_utils_extended.py
@@ -240,9 +240,13 @@ def test_open_file_location_existing_file(tmp_path):
 # process_file
 # ---------------------------------------------------------------------------
 
-def test_process_file_image(tmp_path):
+def test_process_file_image(tmp_path, monkeypatch):
     f = tmp_path / "test.jpg"
     f.write_bytes(b"data")
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file",
+        lambda path, mime=True: "image/jpeg",
+    )
     image_cb = MagicMock()
     video_cb = MagicMock()
     process_file(str(f), image_cb, video_cb)
@@ -250,9 +254,13 @@ def test_process_file_image(tmp_path):
     video_cb.assert_not_called()
 
 
-def test_process_file_video(tmp_path):
+def test_process_file_video(tmp_path, monkeypatch):
     f = tmp_path / "test.mp4"
     f.write_bytes(b"data")
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file",
+        lambda path, mime=True: "video/mp4",
+    )
     image_cb = MagicMock()
     video_cb = MagicMock()
     process_file(str(f), image_cb, video_cb)

--- a/tests/core/test_utils_extended.py
+++ b/tests/core/test_utils_extended.py
@@ -117,11 +117,19 @@ def test_validate_report_dir_empty():
 # detect_media_type_utils
 # ---------------------------------------------------------------------------
 
-def test_detect_media_type_utils_image():
+def test_detect_media_type_utils_image(monkeypatch):
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file",
+        lambda path, mime=True: "image/jpeg",
+    )
     assert detect_media_type_utils("photo.jpg") == "image"
 
 
-def test_detect_media_type_utils_video():
+def test_detect_media_type_utils_video(monkeypatch):
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file",
+        lambda path, mime=True: "video/mp4",
+    )
     assert detect_media_type_utils("clip.mp4") == "video"
 
 
@@ -266,10 +274,20 @@ def test_process_file_unsupported(tmp_path):
 # count_supported_files
 # ---------------------------------------------------------------------------
 
-def test_count_supported_files(tmp_path):
+def test_count_supported_files(tmp_path, monkeypatch):
     (tmp_path / "a.jpg").write_bytes(b"")
     (tmp_path / "b.mp4").write_bytes(b"")
     (tmp_path / "c.txt").write_bytes(b"")
+
+    def fake_from_file(path, mime=True):
+        if path.endswith(".jpg"):
+            return "image/jpeg"
+        if path.endswith(".mp4"):
+            return "video/mp4"
+        return "text/plain"
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file", fake_from_file,
+    )
     count = count_supported_files(str(tmp_path))
     assert count == 2
 
@@ -282,12 +300,22 @@ def test_count_supported_files_empty(tmp_path):
 # classify_files_in_folder
 # ---------------------------------------------------------------------------
 
-def test_classify_files_in_folder_basic(tmp_path):
+def test_classify_files_in_folder_basic(tmp_path, monkeypatch):
     from src.core.utils import classify_files_in_folder
 
     (tmp_path / "a.jpg").write_bytes(b"")
     (tmp_path / "b.mp4").write_bytes(b"")
     (tmp_path / "c.txt").write_bytes(b"")
+
+    def fake_from_file(path, mime=True):
+        if path.endswith(".jpg"):
+            return "image/jpeg"
+        if path.endswith(".mp4"):
+            return "video/mp4"
+        return "text/plain"
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file", fake_from_file,
+    )
 
     image_cb = MagicMock()
     video_cb = MagicMock()

--- a/tests/processing/test_media_processor.py
+++ b/tests/processing/test_media_processor.py
@@ -30,9 +30,10 @@ from src.processing.media_processor import FrameExtractor, detect_media_type, is
 ])
 def test_detect_media_type(monkeypatch, file_path, mime, expected):
     if mime is not None:
+        expected_mime = mime
         monkeypatch.setattr(
             "src.processing.media_processor.magic.from_file",
-            lambda path, mime=True: mime,
+            lambda path, mime=True: expected_mime,
         )
     assert detect_media_type(file_path) == expected
 

--- a/tests/processing/test_media_processor.py
+++ b/tests/processing/test_media_processor.py
@@ -20,19 +20,58 @@ from src.core import constants
 from src.processing.media_processor import FrameExtractor, detect_media_type, is_supported_file
 
 
-@pytest.mark.parametrize("file_path,expected", [
-    ("photo.jpg", constants.MEDIA_TYPE_IMAGE),
-    ("photo.JPEG", constants.MEDIA_TYPE_IMAGE),
-    ("clip.mp4", constants.MEDIA_TYPE_VIDEO),
-    ("movie.MKV", constants.MEDIA_TYPE_VIDEO),
-    ("document.pdf", constants.MEDIA_TYPE_UNKNOWN),
-    ("no_extension", constants.MEDIA_TYPE_UNKNOWN),
+@pytest.mark.parametrize("file_path,mime,expected", [
+    ("photo.jpg", "image/jpeg", constants.MEDIA_TYPE_IMAGE),
+    ("photo.JPEG", "image/jpeg", constants.MEDIA_TYPE_IMAGE),
+    ("clip.mp4", "video/mp4", constants.MEDIA_TYPE_VIDEO),
+    ("movie.MKV", "video/x-matroska", constants.MEDIA_TYPE_VIDEO),
+    ("document.pdf", None, constants.MEDIA_TYPE_UNKNOWN),
+    ("no_extension", None, constants.MEDIA_TYPE_UNKNOWN),
 ])
-def test_detect_media_type(file_path, expected):
+def test_detect_media_type(monkeypatch, file_path, mime, expected):
+    if mime is not None:
+        monkeypatch.setattr(
+            "src.processing.media_processor.magic.from_file",
+            lambda path, mime=True: mime,
+        )
     assert detect_media_type(file_path) == expected
 
 
-def test_is_supported_file_true():
+def test_detect_media_type_extension_mime_mismatch(monkeypatch):
+    """A .jpg-extensioned file whose magic bytes are not an image MIME is UNKNOWN."""
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file",
+        lambda path, mime=True: "application/octet-stream",
+    )
+    assert detect_media_type("payload.jpg") == constants.MEDIA_TYPE_UNKNOWN
+
+
+def test_detect_media_type_video_octet_stream_rejected(monkeypatch):
+    """A .mp4-extensioned file reporting application/octet-stream is UNKNOWN,
+    not video — regression guard against the video-path bypass identified in review."""
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file",
+        lambda path, mime=True: "application/octet-stream",
+    )
+    assert detect_media_type("payload.mp4") == constants.MEDIA_TYPE_UNKNOWN
+
+
+def test_detect_media_type_magic_error_returns_unknown(monkeypatch):
+    """magic.from_file raising OSError/MagicException maps to MEDIA_TYPE_UNKNOWN,
+    it must not propagate."""
+    def _raise(path, mime=True):
+        raise OSError("cannot read file")
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file", _raise,
+    )
+    assert detect_media_type("photo.jpg") == constants.MEDIA_TYPE_UNKNOWN
+
+
+def test_is_supported_file_true(monkeypatch):
+    monkeypatch.setattr(
+        "src.processing.media_processor.magic.from_file",
+        lambda path, mime=True: "image/png",
+    )
     assert is_supported_file("image.png") is True
 
 


### PR DESCRIPTION
This pull request introduces a robust security improvement to media type detection by verifying file content using magic-byte (MIME) inspection, rather than trusting file extensions alone. It integrates the `python-magic` library and system `libmagic` dependency, updates the detection logic and allowlists, and thoroughly adapts and extends test coverage to ensure the new checks work as intended and prevent extension-based spoofing attacks.

**Security and Media Type Detection Enhancements**
* The `detect_media_type` function now uses both file extension and magic-byte MIME type verification (via `python-magic`/`libmagic`), cross-checking against strict allowlists for images and videos. This prevents files with spoofed extensions but invalid content from being misclassified, closing a key security gap. (`src/processing/media_processor.py`, `src/core/constants.py`) [[1]](diffhunk://#diff-e99bff78f183266dff42fe4ab15c9a94b1f736a795b78cb6095c0872be33ab3eL29-R37) [[2]](diffhunk://#diff-e99bff78f183266dff42fe4ab15c9a94b1f736a795b78cb6095c0872be33ab3eL40-R59) [[3]](diffhunk://#diff-4992c45370cc3d34a4d5ade80b891b62eb2f8c3165a38592d1b50e522c97d4a6R15-R27)
* The MIME allowlists (`MIME_IMAGE_TYPES`, `MIME_VIDEO_TYPES`) are carefully scoped to exclude generic types like `application/octet-stream`, so only recognized, valid media files are accepted. (`src/core/constants.py`)

**Dependency and Documentation Updates**
* Adds `python-magic` to `requirements.in` and instructs users to install the `libmagic` system library, with clear documentation in `README.md`. (`requirements.in`, `README.md`) [[1]](diffhunk://#diff-de469cc9cf8992ffaec661b4e087cfded3ec6da722072ec1fdf11f61690fd1b8R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R95)

**Testing Improvements**
* All tests that depend on media type detection now use `monkeypatch` to mock `magic.from_file`, ensuring deterministic and isolated test results. This includes both core and processing test modules. (`tests/core/test_utils_extended.py`, `tests/processing/test_media_processor.py`) [[1]](diffhunk://#diff-9fcf5d9e6e1cee044ba9dbf9341218e06157c6bc2f482b3c1721627849a8667cL120-R132) [[2]](diffhunk://#diff-9fcf5d9e6e1cee044ba9dbf9341218e06157c6bc2f482b3c1721627849a8667cL235-R263) [[3]](diffhunk://#diff-9fcf5d9e6e1cee044ba9dbf9341218e06157c6bc2f482b3c1721627849a8667cL269-R298) [[4]](diffhunk://#diff-9fcf5d9e6e1cee044ba9dbf9341218e06157c6bc2f482b3c1721627849a8667cL285-R327) [[5]](diffhunk://#diff-2ec60009c573d9a4ce208aa6d73a9ab13467dd72068c8f4f4476a5261eaa0c72L23-R75)
* New regression tests explicitly verify that files with valid extensions but invalid or generic MIME types are correctly rejected, and that errors in MIME detection result in a safe fallback (`MEDIA_TYPE_UNKNOWN`). (`tests/processing/test_media_processor.py`)

These changes significantly harden the application against malicious media files and extension spoofing attacks, while maintaining clear, testable, and well-documented code.