### PR TITLE
fix: resolve #55 - FEATURE: Resolve redundant opencv-python and opencv-python-h

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,6 @@ nudenet>=3.4.2,<4
 VNudeNet>=2.1.0,<3
 openpyxl>=3.1.5,<4
 Pillow>=12.3.0,<13
-opencv-python>=5.0.0.93,<6
 requests>=2.34.2,<3
 Send2Trash>=2.1.0,<3
 darkdetect>=0.8.0,<1

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ numpy==2.4.6
     #   nudenet
     #   onnxruntime
     #   onnxruntime-gpu
-    #   opencv-python
     #   opencv-python-headless
     #   scikit-image
     #   scipy
@@ -41,8 +40,6 @@ onnxruntime==1.26.0
     # via nudenet
 onnxruntime-gpu==1.26.0
     # via vnudenet
-opencv-python==5.0.0.93
-    # via -r requirements.in
 opencv-python-headless==4.13.0.92
     # via
     #   nudenet


### PR DESCRIPTION
## Summary
Resolves #55 — FEATURE: Resolve redundant opencv-python and opencv-python-headless co-installation

**Project:** [Nudity Detector project](#10) — _Backlog_
## Changes
- ### Issue 1
- ### Issue 2

**Tasks:**
- Remove the `opencv-python>=5.0.0.93,<6` line from `requirements.in`
- Confirm `opencv-python-headless` remains available transitively via `nudenet` and `VNudeNet`
- Run `pip-compile --output-file=requirements.txt requirements.in` to regenerate the pinned
- Confirm `requirements.txt` no longer contains an `opencv-python==...` block
- Confirm `requirements.txt` retains a single `opencv-python-headless==...` block with
- Confirm the `numpy` entry's `# via` comment no longer references `opencv-python` (only
- Create a fresh venv, install `requirements.txt`, and confirm `import cv2` succeeds
- Run `pip-audit -r requirements.txt` to confirm no new vulnerabilities were introduced
- All existing and new tests pass locally (pytest / mvn test / npm test / etc.)
- All existing and new lint checks pass locally (ruff / eslint / ng lint / etc.)
## Testing
Run the full test suite — all tests must pass.
Closes #55