### PR TITLE
fix: resolve #72 - FEATURE: Document all .env.example variables with their conf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,93 @@
-# Helloz NSFW API configuration
-# Set these keys in config/app_config.json to override the defaults below.
+# app_config.json — Complete Configuration Reference
 #
-# {
-#   "helloz_nsfw_scheme":       "http",              (use "https" for non-local hosts)
-#   "helloz_nsfw_host":         "localhost",
-#   "helloz_nsfw_port":         6086,
-#   "helloz_nsfw_api_endpoint": "/api/upload_check"
-# }
+# This file is the sole configuration surface for the Nudity Detector application.
+# No environment-variable overrides are supported (no python-dotenv or os.environ
+# usage exists in this codebase). All runtime settings live in config/app_config.json.
+#
+# Every key below is listed with its default value, the corresponding constant in
+# src/core/constants.py that backs that default in code, and whether it is
+# Helloz-NSFW-specific or app-wide.
+#
+# Legend:
+#   [app-wide]         Key applies to the whole application (all backends).
+#   [Helloz-NSFW]     Key is specific to the Helloz NSFW remote detection backend.
+#
+# Keys without a constants.py counterpart are marked "no constant" and are read
+# directly from app_config.json at runtime.
+
+{
+  "theme": "dark",
+  # [app-wide]  GUI theme: "system", "light", or "dark".
+  # Backed by: THEME_DARK in src/core/constants.py.
+
+  "model": "helloz_nsfw",
+  # [app-wide]  Default detection model: "nudenet" or "helloz_nsfw".
+  # No constants.py counterpart — used directly from config.
+
+  "threshold_percent": 60.0,
+  # [app-wide]  Nudity detection threshold (0.0–100.0).
+  # Backed by: DEFAULT_THRESHOLD_PERCENT in src/core/constants.py.
+
+  "last_source_folder": "/home/dewald/Pictures",
+  # [app-wide]  Default source folder opened in the GUI.
+  # No constants.py counterpart — used directly from config.
+
+  "progress_update_interval": 100,
+  # [app-wide]  Flush UI results every N files processed.
+  # Backed by: SCAN_PROGRESS_UPDATE_INTERVAL (100) in src/core/constants.py.
+
+  "video_frame_rate": 10,
+  # [app-wide]  Extract every Nth frame when scanning videos.
+  # Backed by: VIDEO_FRAME_RATE (5) in src/core/constants.py.
+  # NOTE: the constant default (5) differs from the config default (10).
+
+  "worker_thread_count": 10,
+  # [app-wide]  General worker thread pool size.
+  # No constants.py counterpart — used directly from config.
+
+  "worker_thread_timeout": 250,
+  # [app-wide]  General worker thread timeout (ms).
+  # No constants.py counterpart — used directly from config.
+
+  "nudenet_worker_thread_count": 4,
+  # [app-wide]  NudeNet-specific worker thread count.
+  # No constants.py counterpart — used directly from config.
+
+  "nudenet_worker_thread_timeout": 10,
+  # [app-wide]  NudeNet-specific worker thread timeout (ms).
+  # No constants.py counterpart — used directly from config.
+
+  "helloz_nsfw_worker_thread_count": 20,
+  # [Helloz-NSFW]  Helloz NSFW worker thread count.
+  # No constants.py counterpart — used directly from config.
+
+  "helloz_nsfw_worker_thread_timeout": 35,
+  # [Helloz-NSFW]  Helloz NSFW worker thread timeout (ms).
+  # No constants.py counterpart — used directly from config.
+
+  "detect_timeout": 250,
+  # [app-wide]  Timeout for individual detection calls (ms).
+  # Backed by: DETECT_TIMEOUT (60, seconds) in src/core/constants.py.
+  # NOTE: the constant default is in seconds (60); the config value is in ms (250).
+
+  "helloz_nsfw_host": "localhost",
+  # [Helloz-NSFW]  Helloz NSFW server hostname.
+  # Backed by: HELLOZ_NSFW_HOST in src/core/constants.py.
+
+  "helloz_nsfw_port": 6086,
+  # [Helloz-NSFW]  Helloz NSFW server port.
+  # Backed by: HELLOZ_NSFW_PORT in src/core/constants.py.
+
+  "helloz_nsfw_api_endpoint": "/api/upload_check",
+  # [Helloz-NSFW]  Helloz NSFW upload-check API path.
+  # Backed by: HELLOZ_NSFW_API_ENDPOINT in src/core/constants.py.
+
+  "helloz_nsfw_request_timeout": 300,
+  # [Helloz-NSFW]  HTTP request timeout for Helloz NSFW calls (seconds).
+  # Backed by: HELLOZ_NSFW_REQUEST_TIMEOUT (30) in src/core/constants.py.
+  # NOTE: the constant default (30s) differs from the config default (300s).
+
+  "helloz_nsfw_health_check_timeout": 5
+  # [Helloz-NSFW]  Health-check timeout for Helloz NSFW (seconds).
+  # Backed by: HELLOZ_NSFW_HEALTH_CHECK_TIMEOUT (5) in src/core/constants.py.
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Two detector backends:
 | Path | Contents |
 |---|---|
 | `config/app_config.json` | Runtime config — Helloz host/port/endpoint |
-| `.env.example` | Available env overrides with defaults |
+| `.env.example` | Config-key reference table — all `app_config.json` keys, their code-default constants, and default values |
 | `reports/` | Generated Excel reports (`nudity_report.xlsx`) |
 | `scripts/` | Linux build script + PyInstaller spec |
 | `tests/` | Pytest test suite |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,55 @@ Two detector backends are available:
 
    - The Helloz NSFW endpoint is configurable via `config/app_config.json` using the keys
      `helloz_nsfw_host`, `helloz_nsfw_port`, and `helloz_nsfw_api_endpoint`.
-     See `.env.example` for the available settings and their default values.
+
+## Configuration
+
+The Nudity Detector application has a single configuration surface: `config/app_config.json`.
+No environment-variable overrides are supported — there is no `python-dotenv` or `os.environ`
+usage anywhere in the codebase. `.env.example` is a plain-text reference table documenting all
+`app_config.json` keys, their code-default constants (where applicable), and default values; it
+is not an env-var template.
+
+All 18 keys in `config/app_config.json`:
+
+| Key | Default | Constant (src/core/constants.py) | Scope |
+|-----|---------|----------------------------------|-------|
+| `theme` | `"dark"` | `THEME_DARK` | app-wide |
+| `model` | `"helloz_nsfw"` | *no constant* | app-wide |
+| `threshold_percent` | `60.0` | `DEFAULT_THRESHOLD_PERCENT` | app-wide |
+| `last_source_folder` | `"/home/dewald/Pictures"` | *no constant* | app-wide |
+| `progress_update_interval` | `100` | `SCAN_PROGRESS_UPDATE_INTERVAL` | app-wide |
+| `video_frame_rate` | `10` | `VIDEO_FRAME_RATE` (code default: 5) | app-wide |
+| `worker_thread_count` | `10` | *no constant* | app-wide |
+| `worker_thread_timeout` | `250` | *no constant* | app-wide |
+| `nudenet_worker_thread_count` | `4` | *no constant* | app-wide |
+| `nudenet_worker_thread_timeout` | `10` | *no constant* | app-wide |
+| `helloz_nsfw_worker_thread_count` | `20` | *no constant* | Helloz-NSFW |
+| `helloz_nsfw_worker_thread_timeout` | `35` | *no constant* | Helloz-NSFW |
+| `detect_timeout` | `250` | `DETECT_TIMEOUT` (code default: 60 s) | app-wide |
+| `helloz_nsfw_host` | `"localhost"` | `HELLOZ_NSFW_HOST` | Helloz-NSFW |
+| `helloz_nsfw_port` | `6086` | `HELLOZ_NSFW_PORT` | Helloz-NSFW |
+| `helloz_nsfw_api_endpoint` | `"/api/upload_check"` | `HELLOZ_NSFW_API_ENDPOINT` | Helloz-NSFW |
+| `helloz_nsfw_request_timeout` | `300` | `HELLOZ_NSFW_REQUEST_TIMEOUT` (code default: 30 s) | Helloz-NSFW |
+| `helloz_nsfw_health_check_timeout` | `5` | `HELLOZ_NSFW_HEALTH_CHECK_TIMEOUT` | Helloz-NSFW |
+
+Note on units: `detect_timeout`, `worker_thread_timeout`,
+`nudenet_worker_thread_timeout`, `helloz_nsfw_worker_thread_timeout`, and
+`helloz_nsfw_worker_thread_count` are stored in milliseconds in
+`config/app_config.json` but the corresponding constants in
+`src/core/constants.py` use seconds where applicable — the values differ by design
+and are not interchangeable.
+
+Five keys have no corresponding constant in `src/core/constants.py` and are read
+directly from `config/app_config.json` at runtime:
+`last_source_folder`, `nudenet_worker_thread_count`,
+`nudenet_worker_thread_timeout`, `helloz_nsfw_worker_thread_count`, and
+`helloz_nsfw_worker_thread_timeout`.
+
+Startup validation: if `config/app_config.json` is missing or contains invalid JSON,
+`_load_helloz_config` in `src/core/constants.py` logs a `WARNING` and falls back to
+the built-in defaults from `constants.py`. See the `logger.warning` call in that
+function for the exact message.
 
 9. **Run the process**:
 

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -3,7 +3,10 @@ Centralized constants for the Nudity Detector application.
 Provides single source of truth for configuration values, avoiding magic numbers.
 """
 import json
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # Media Type Configuration
@@ -149,6 +152,10 @@ def _load_helloz_config():
             scheme = 'http' if host in _LOOPBACK_HOSTS else 'https'
         return host, port, endpoint, scheme
     except (OSError, json.JSONDecodeError):
+        logger.warning(
+            "app_config.json not found or invalid at %s; using built-in defaults",
+            _config_path(),
+        )
         return HELLOZ_NSFW_HOST, HELLOZ_NSFW_PORT, HELLOZ_NSFW_API_ENDPOINT, 'http'
 
 

--- a/tests/core/test_constants_issue72.py
+++ b/tests/core/test_constants_issue72.py
@@ -3,13 +3,12 @@ Tests for issue #72 — startup validation logging in _load_helloz_config.
 """
 from unittest import mock
 
-import pytest
+from src.core import constants
 
 
 class TestLoadHellozConfigWarning:
     def test_warning_emitted_when_config_missing(self):
         """_load_helloz_config logs a warning when app_config.json is missing."""
-        from src.core import constants
         with mock.patch('builtins.open', side_effect=OSError('not found')):
             with mock.patch.object(constants.logger, 'warning') as mock_warning:
                 result = constants._load_helloz_config()
@@ -24,9 +23,6 @@ class TestLoadHellozConfigWarning:
 
     def test_warning_emitted_when_config_malformed(self, tmp_path):
         """_load_helloz_config logs a warning when app_config.json is malformed."""
-        from src.core import constants
-        import json
-        import os
         config_path = tmp_path / 'app_config.json'
         config_path.write_text('{ not valid json')
         original_path = constants._config_path()

--- a/tests/core/test_constants_issue72.py
+++ b/tests/core/test_constants_issue72.py
@@ -1,0 +1,47 @@
+"""
+Tests for issue #72 — startup validation logging in _load_helloz_config.
+"""
+from unittest import mock
+
+import pytest
+
+
+class TestLoadHellozConfigWarning:
+    def test_warning_emitted_when_config_missing(self):
+        """_load_helloz_config logs a warning when app_config.json is missing."""
+        from src.core import constants
+        with mock.patch('builtins.open', side_effect=OSError('not found')):
+            with mock.patch.object(constants.logger, 'warning') as mock_warning:
+                result = constants._load_helloz_config()
+        assert result == (constants.HELLOZ_NSFW_HOST,
+                          constants.HELLOZ_NSFW_PORT,
+                          constants.HELLOZ_NSFW_API_ENDPOINT,
+                          'http')
+        mock_warning.assert_called_once()
+        msg = mock_warning.call_args[0][0]
+        assert 'app_config.json not found or invalid' in msg
+        assert 'using built-in defaults' in msg
+
+    def test_warning_emitted_when_config_malformed(self, tmp_path):
+        """_load_helloz_config logs a warning when app_config.json is malformed."""
+        from src.core import constants
+        import json
+        import os
+        config_path = tmp_path / 'app_config.json'
+        config_path.write_text('{ not valid json')
+        original_path = constants._config_path()
+        try:
+            with mock.patch.object(constants, '_config_path', return_value=str(config_path)):
+                with mock.patch.object(constants.logger, 'warning') as mock_warning:
+                    result = constants._load_helloz_config()
+            assert result == (constants.HELLOZ_NSFW_HOST,
+                              constants.HELLOZ_NSFW_PORT,
+                              constants.HELLOZ_NSFW_API_ENDPOINT,
+                              'http')
+            mock_warning.assert_called_once()
+            msg = mock_warning.call_args[0][0]
+            assert 'app_config.json not found or invalid' in msg
+            assert 'using built-in defaults' in msg
+        finally:
+            if str(config_path) != original_path:
+                pass


### PR DESCRIPTION
## Summary

Resolves #72 — Documents all 18 `config/app_config.json` keys with their `constants.py` counterparts, adds startup validation warning when the config file is missing, and corrects misleading references to `.env.example` as an environment-variable template.

## Changes

- **`.env.example`**: Rewritten from a 4-key JSON template comment block to a comprehensive 90+ line configuration reference documenting all 18 keys from `config/app_config.json`, each with its default value, the corresponding `src/core/constants.py` constant that backs it, and whether it is Helloz-NSFW-specific or app-wide.

- **`README.md`**: Added a "Configuration" section (after the "Prepare Models" step) documenting that `config/app_config.json` is the sole configuration surface, listing all 18 keys with their defaults, and explicitly stating that no environment-variable overrides are supported.

- **`AGENTS.md`**: Corrected line 29 description of `.env.example` from "Available env overrides with defaults" to accurately reflect that it is a config-key reference document, not an environment-variable template.

- **`src/core/constants.py`**: Added `import logging` and `logger = logging.getLogger(__name__)` at module level, and replaced the silent `except` fallback in `_load_helloz_config` (line 151-152) with a `logger.warning` call that emits when `app_config.json` is missing or unreadable, before returning built-in defaults.

- **`tests/core/test_constants_issue72.py`**: Added a pytest test that mocks `open` to raise `OSError`, calls `_load_helloz_config`, and asserts that `logger.warning` was emitted with the expected message confirming the config file was not found.

## Testing

- Run `pytest tests/core/test_constants_issue72.py -v` to verify the new warning test passes.
- Run the full test suite with `pytest` to confirm no regressions.
- Manually verify by temporarily renaming `config/app_config.json` and running the application — a warning should appear in the log output indicating the config file was not found and defaults are being used.

## Closes #72